### PR TITLE
UnionAlg typo

### DIFF
--- a/src/algorithms/unionalg.jl
+++ b/src/algorithms/unionalg.jl
@@ -20,7 +20,7 @@ function changebonds(state,H,alg::UnionAlg,envs=environments(state,H))
     return (state,envs)
 end
 
-function find_groundstate(state,opperator,alg::UnionAlg,envs=environments(state,H))
-    (state,envs) = find_groundstate(state,opperator,alg.alg1,envs);
-    (state,envs,delta) = find_groundstate(state,opperator,alg.alg2,envs);
+function find_groundstate(state,H,alg::UnionAlg,envs=environments(state,H))
+    (state,envs) = find_groundstate(state,H,alg.alg1,envs);
+    (state,envs,delta) = find_groundstate(state,H,alg.alg2,envs);
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,7 @@ println("------------------------------------")
         (InfiniteMPS([ℂ^2],[ℂ^10]), GradientGrassmann(method=LBFGS(6; gradtol=1e-8, verbosity=0)), nonsym_ising_ham(lambda=2.0)),
         (InfiniteMPS([ℂ^2],[ℂ^10]),Idmrg1(tol_galerkin=1e-8,maxiter=400,verbose=false),nonsym_ising_ham(lambda=2.0)),
         (InfiniteMPS([ℂ^2,ℂ^2],[ℂ^10,ℂ^10]),Idmrg2(trscheme = truncdim(12),tol_galerkin=1e-8,maxiter=400,verbose=false),repeat(nonsym_ising_ham(lambda=2.0),2)),
+        (InfiniteMPS([ℂ^2], [ℂ^10]), Vumps(tol_galerkin=1e-5,verbose=false)&GradientGrassmann(tol=1e-8, verbosity=0), nonsym_ising_ham(lambda=2.0)),
         (FiniteMPS(rand,ComplexF64,10,ℂ^2,ℂ^10),Dmrg2(verbose=false,trscheme=truncdim(10)),nonsym_ising_ham(lambda=2.0)),
         (FiniteMPS(rand,ComplexF64,10,ℂ^2,ℂ^10),Dmrg(verbose=false),nonsym_ising_ham(lambda=2.0)),
         (FiniteMPS(rand,ComplexF64,10,ℂ^2,ℂ^10),GradientGrassmann(verbosity=0),nonsym_ising_ham(lambda=2.0))


### PR DESCRIPTION
Fixes a small typo (inconsistent variable naming ```H - opperator```) and adds a simple test.