### PR TITLE
Add dynamical tolerance scaling for `VUMPS`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Maarten Van Damme", "Jutho Haegeman", "Lukas Devos", "Gertian Roose"
 version = "0.9.0"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
 FoldsThreads = "9c68100b-dfe1-47cf-94c8-95104e173443"

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -5,6 +5,7 @@ using Base.Threads, FLoops, Transducers, FoldsThreads
 using Base.Iterators
 using RecipesBase
 using VectorInterface
+using Accessors
 
 using LinearAlgebra: diag, Diagonal
 using LinearAlgebra: LinearAlgebra

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -37,7 +37,7 @@ end
 
 function updatetols(alg::VUMPS, iter, ε)
     if alg.dynamical_tols
-        tol_eigs =  between(alg.tol_min, ε * alg.eigs_tolfactor / sqrt(iter), alg.tol_max)
+        tol_eigs = between(alg.tol_min, ε * alg.eigs_tolfactor / sqrt(iter), alg.tol_max)
         tol_envs = between(alg.tol_min, ε * alg.envs_tolfactor / sqrt(iter), alg.tol_max)
         tol_gauge = between(alg.tol_min, ε * alg.gauge_tolfactor / sqrt(iter), alg.tol_max)
     else # preserve legacy behavior

--- a/src/environments/mpohaminfenv.jl
+++ b/src/environments/mpohaminfenv.jl
@@ -53,19 +53,22 @@ function rightenv(envs::MPOHamInfEnv, pos::Int, state)
     return envs.rw[:, pos]
 end
 
-function recalculate!(envs::MPOHamInfEnv, nstate)
+function recalculate!(envs::MPOHamInfEnv, nstate; tol=envs.solver.tol)
     sameDspace = reduce(&, _lastspace.(envs.lw[1, :]) .== _firstspace.(nstate.CR))
 
     if !sameDspace
         (envs.lw, envs.rw) = gen_lw_rw(nstate, envs.opp)
     end
 
+    solver = envs.solver
+    solver = @set solver.tol=tol
     @sync begin
-        Threads.@spawn calclw!(envs.lw, nstate, envs.opp; solver=envs.solver)
-        Threads.@spawn calcrw!(envs.rw, nstate, envs.opp; solver=envs.solver)
+        Threads.@spawn calclw!(envs.lw, nstate, envs.opp; solver=solver)
+        Threads.@spawn calcrw!(envs.rw, nstate, envs.opp; solver=solver)
     end
 
     envs.dependency = nstate
+    envs.solver = solver
 
     return envs
 end

--- a/src/environments/mpohaminfenv.jl
+++ b/src/environments/mpohaminfenv.jl
@@ -61,7 +61,7 @@ function recalculate!(envs::MPOHamInfEnv, nstate; tol=envs.solver.tol)
     end
 
     solver = envs.solver
-    solver = @set solver.tol=tol
+    solver = @set solver.tol = tol
     @sync begin
         Threads.@spawn calclw!(envs.lw, nstate, envs.opp; solver=solver)
         Threads.@spawn calcrw!(envs.rw, nstate, envs.opp; solver=solver)

--- a/src/environments/mpohaminfenv.jl
+++ b/src/environments/mpohaminfenv.jl
@@ -61,10 +61,10 @@ function recalculate!(envs::MPOHamInfEnv, nstate; tol=envs.solver.tol)
     end
 
     solver = envs.solver
-    solver = @set solver.tol = tol
+    solver = solver.tol == tol ? solver : @set solver.tol = tol
     @sync begin
-        Threads.@spawn calclw!(envs.lw, nstate, envs.opp; solver=solver)
-        Threads.@spawn calcrw!(envs.rw, nstate, envs.opp; solver=solver)
+        Threads.@spawn calclw!(envs.lw, nstate, envs.opp; solver)
+        Threads.@spawn calcrw!(envs.rw, nstate, envs.opp; solver)
     end
 
     envs.dependency = nstate

--- a/src/environments/permpoinfenv.jl
+++ b/src/environments/permpoinfenv.jl
@@ -62,7 +62,7 @@ function recalculate!(envs::PerMPOInfEnv, nstate::MPSMultiline; tol=envs.solver.
     end
 
     solver = envs.solver
-    solver = @set solver.tol=tol
+    solver = @set solver.tol = tol
     (envs.lw, envs.rw) = mixed_fixpoints(above, envs.opp, nstate, init; solver)
     envs.dependency = nstate
     envs.solver = solver

--- a/src/environments/permpoinfenv.jl
+++ b/src/environments/permpoinfenv.jl
@@ -49,10 +49,10 @@ function environments(
     return PerMPOInfEnv(above, mpo, below, solver, lw, rw, ReentrantLock())
 end
 
-function recalculate!(envs::PerMPOInfEnv, nstate::InfiniteMPS)
-    return recalculate!(envs, convert(MPSMultiline, nstate))
+function recalculate!(envs::PerMPOInfEnv, nstate::InfiniteMPS; kwargs...)
+    return recalculate!(envs, convert(MPSMultiline, nstate); kwargs...)
 end;
-function recalculate!(envs::PerMPOInfEnv, nstate::MPSMultiline)
+function recalculate!(envs::PerMPOInfEnv, nstate::MPSMultiline; tol=envs.solver.tol)
     sameDspace = reduce(&, _firstspace.(envs.dependency.CR) .== _firstspace.(nstate.CR))
 
     above = isnothing(envs.above) ? nstate : envs.above
@@ -61,8 +61,11 @@ function recalculate!(envs::PerMPOInfEnv, nstate::MPSMultiline)
         init = gen_init_fps(above, envs.opp, nstate)
     end
 
-    (envs.lw, envs.rw) = mixed_fixpoints(above, envs.opp, nstate, init; solver=envs.solver)
+    solver = envs.solver
+    solver = @set solver.tol=tol
+    (envs.lw, envs.rw) = mixed_fixpoints(above, envs.opp, nstate, init; solver)
     envs.dependency = nstate
+    envs.solver = solver
 
     return envs
 end

--- a/src/environments/permpoinfenv.jl
+++ b/src/environments/permpoinfenv.jl
@@ -62,7 +62,7 @@ function recalculate!(envs::PerMPOInfEnv, nstate::MPSMultiline; tol=envs.solver.
     end
 
     solver = envs.solver
-    solver = @set solver.tol = tol
+    solver = solver.tol == tol ? solver : @set solver.tol = tol
     (envs.lw, envs.rw) = mixed_fixpoints(above, envs.opp, nstate, init; solver)
     envs.dependency = nstate
     envs.solver = solver

--- a/src/utility/defaults.jl
+++ b/src/utility/defaults.jl
@@ -13,11 +13,17 @@ const maxiter = 100
 const tolgauge = 1e-14
 const tol = 1e-12
 const verbose = true
+const dynamical_tols = true
+const tol_min = 1e-14
+const tol_max = 1e-5
+const eigs_tolfactor = 1e-5
+const gauge_tolfactor = 1e-8
+const envs_tolfactor = 1e-5
 
 _finalize(iter, state, opp, envs) = (state, envs)
 
 const linearsolver = GMRES(; tol, maxiter)
-const eigsolver = Arnoldi(; tol, maxiter)
+const eigsolver = Arnoldi(; tol, maxiter, eager=true)
 
 # Preferences
 # -----------

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -149,4 +149,4 @@ function between(x1, x, x2)
     x < x1 && return x1
     x > x2 && return x2
     return x
-end 
+end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -143,3 +143,10 @@ end
 @static if !isdefined(Base, :allequal)
     allequal(itr) = isempty(itr) ? true : all(isequal(first(itr)), itr)
 end
+
+function between(x1, x, x2)
+    @assert x1 <= x2 "x1 should be smaller than  or equal to x2"
+    x < x1 && return x1
+    x > x2 && return x2
+    return x
+end 


### PR DESCRIPTION
Adds some optional dynamical tolerance scaling to `VUMPS` which sets the tolerance of the local eigensolver updates, environment recalculation and infinite MPS gauging based on the current galerkin error. I've enabled this by default here since I don't see any clear downsides to having this. We could also keep the default behavior as is and have users switch on tolerance scaling manually. Is this preferable?

In addition, I have set `eager=true` in the default eigenvalue solver to check for early convergence. It seems to me that this is really what you would want to do since basically all eigensolver subroutines get the result of the previous iteration as an initial guess, and this is generally pretty good. For my current use cases (variational PEPS optimization) this gives a speedup by over a factor of 2. If we don't want to have this eager behavior by default, it would at the very least be good to have better access to the actual eigensolver settings when initializing a `VUMPS` instance.