### PR TITLE
Fix #93 Rewrite FiniteMPS constructors

### DIFF
--- a/src/environments/FinEnv.jl
+++ b/src/environments/FinEnv.jl
@@ -71,15 +71,12 @@ end
 
 function MPSKit.environments(below::FiniteMPS{S}, O::DenseMPO, above=nothing) where {S}
     N = length(below)
-    leftstart = isomorphism(
-        storagetype(S),
-        left_virtualspace(below, 0) ⊗ space(O[1], 1)' ← left_virtualspace(below, 0),
-    )
-    rightstart = isomorphism(
-        storagetype(S),
-        right_virtualspace(below, N) ⊗ space(O[N], 4)' ←
-        right_virtualspace(below, length(below)),
-    )
+    leftstart = isomorphism(storagetype(S),
+                            left_virtualspace(below, 0) ⊗ space(O[1], 1)' ←
+                            left_virtualspace(below, 0))
+    rightstart = isomorphism(storagetype(S),
+                             right_virtualspace(below, N) ⊗ space(O[N], 4)' ←
+                             right_virtualspace(below, length(below)))
     return environments(below, O, above, leftstart, rightstart)
 end
 

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -172,12 +172,13 @@ function FiniteMPS(f, elt, Pspaces::Vector{<:Union{S,CompositeSpace{S}}},
                    maxVspaces::Vector{S}; normalize=true, left::S=oneunit(S),
                    right::S=oneunit(S)) where {S<:ElementarySpace}
     N = length(Pspaces)
-    length(maxVspaces) == N - 1 || throw(DimensionMismatch("length of physical spaces ($N) and virtual spaces $(length(maxVspaces)) should differ by 1"))
-    
+    length(maxVspaces) == N - 1 ||
+        throw(DimensionMismatch("length of physical spaces ($N) and virtual spaces $(length(maxVspaces)) should differ by 1"))
+
     # limit the maximum virtual dimension such that result is full rank
     fusedPspaces = fuse.(Pspaces) # for working with multiple physical spaces
     Vspaces = similar(maxVspaces)
-    
+
     Vspaces[1] = left
     for k in 2:N
         Vspaces[k] = infimum(fuse(Vspaces[k - 1], fusedPspaces[k]), maxVspaces[k - 1])
@@ -218,7 +219,6 @@ FiniteMPS(P::ProductSpace, args...; kwargs...) = FiniteMPS(collect(P), args...; 
 function FiniteMPS(f, elt, P::ProductSpace, args...; kwargs...)
     return FiniteMPS(f, elt, collect(P), args...; kwargs...)
 end
-
 
 #===========================================================================================
 Utility

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -20,14 +20,11 @@ By convention, we have that:
 ---
 
 ## Constructors
-    FiniteMPS([f, eltype], physicalspaces::Vector{<:Union{S, CompositeSpace{S}},
-              virtualspaces::Vector{<:Union{S, CompositeSpace{S}};
-              normalize=true) where {S<:ElementarySpace}
     FiniteMPS([f, eltype], physicalspaces::Vector{<:Union{S,CompositeSpace{S}}},
-              maxvirtualspace::Union{S,Vector{S}};
+              maxvirtualspaces::Union{S,Vector{S}};
               normalize=true, left=oneunit(S), right=oneunit(S)) where {S<:ElementarySpace}
     FiniteMPS([f, eltype], N::Int, physicalspace::Union{S,CompositeSpace{S}},
-              maxvirtualspace::Union{S,Vector{S}};
+              maxvirtualspaces::Union{S,Vector{S}};
               normalize=true, left=oneunit(S), right=oneunit(S)) where {S<:ElementarySpace}
     FiniteMPS(As::Vector{<:GenericMPSTensor}; normalize=false, overwrite=false)
 

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -177,7 +177,7 @@ function FiniteMPS(f, elt, Pspaces::Vector{<:Union{S,CompositeSpace{S}}},
 
     # limit the maximum virtual dimension such that result is full rank
     fusedPspaces = fuse.(Pspaces) # for working with multiple physical spaces
-    Vspaces = similar(maxVspaces)
+    Vspaces = similar(maxVspaces, N + 1)
 
     Vspaces[1] = left
     for k in 2:N


### PR DESCRIPTION
This updates the existing constructors, such that all specifications of virtual spaces are now considered to be an upper bound, instead of a fixed virtual space. This has the following advantages:
- Users can no longer accidentally create non-full rank MPS
- Alternating virtual space specifications can now be achieved easily with `maxvspaces = repeat([V1, V2], N/2)`