### PR TITLE
MultipliedOperator: Functionality for time-evolution of time-dependent Hamiltonians

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -79,6 +79,7 @@ include("operators/sparsempo/sparsempo.jl")
 include("operators/mpohamiltonian.jl") # the mpohamiltonian objects
 include("operators/mpomultiline.jl")
 include("operators/projection.jl")
+include("operators/timedependence.jl")
 include("operators/lazysum.jl")
 
 include("transfermatrix/transfermatrix.jl")

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -27,7 +27,7 @@ export entanglementplot, transferplot
 
 # hamiltonian things
 export Cache
-export SparseMPO, MPOHamiltonian, DenseMPO, MPOMultiline, LazySum
+export SparseMPO, MPOHamiltonian, DenseMPO, MPOMultiline, UntimedOperator, TimedOperator, LazySum
 export ∂C, ∂AC, ∂AC2, environments, expectation_value, effective_excitation_hamiltonian
 export leftenv, rightenv
 
@@ -81,6 +81,7 @@ include("operators/mpomultiline.jl")
 include("operators/projection.jl")
 include("operators/timedependence.jl")
 include("operators/lazysum.jl")
+include("operators/multipliedoperator.jl")
 
 include("transfermatrix/transfermatrix.jl")
 include("transfermatrix/transfer.jl")
@@ -112,6 +113,8 @@ include("algorithms/changebonds/randexpand.jl")
 
 include("algorithms/timestep/tdvp.jl")
 include("algorithms/timestep/timeevmpo.jl")
+include("algorithms/timestep/integrators.jl")
+include("algorithms/timestep/time_evolve.jl")
 
 include("algorithms/groundstate/vumps.jl")
 include("algorithms/groundstate/idmrg.jl")

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -36,7 +36,8 @@ export find_groundstate!, find_groundstate, leading_boundary
 export VUMPS, DMRG, DMRG2, IDMRG1, IDMRG2, GradientGrassmann
 export excitations, FiniteExcited, QuasiparticleAnsatz
 export marek_gap, correlation_length, correlator
-export timestep!, timestep, TDVP, TDVP2, make_time_mpo, WI, WII, TaylorCluster
+export time_evolve, timestep!, timestep
+export TDVP, TDVP2, make_time_mpo, WI, WII, TaylorCluster
 export splitham, infinite_temperature, entanglement_spectrum, transfer_spectrum, variance
 export changebonds!, changebonds, VUMPSSvdCut, OptimalExpand, SvdCut, UnionTrunc, RandExpand
 export entropy
@@ -80,8 +81,8 @@ include("operators/mpohamiltonian.jl") # the mpohamiltonian objects
 include("operators/mpomultiline.jl")
 include("operators/projection.jl")
 include("operators/timedependence.jl")
-include("operators/lazysum.jl")
 include("operators/multipliedoperator.jl")
+include("operators/lazysum.jl")
 
 include("transfermatrix/transfermatrix.jl")
 include("transfermatrix/transfer.jl")

--- a/src/algorithms/derivatives.jl
+++ b/src/algorithms/derivatives.jl
@@ -285,7 +285,8 @@ end
 (h::UntimedOperator{<:DerivativeOperator})(y, args...) = h.f * h.op(y)
 (h::TimedOperator{<:DerivativeOperator})(y, t::Number) = h.f(t) * h.op(y)
 (x::LazySum{<:Union{MultipliedOperator{D}, D} where {D<:DerivativeOperator}})(y, t::Number) = sum(O -> O(y,t), x)
-Base.:*(h::LazySum{<:DerivativeOperator}, v) = h(v)
+(x::LazySum{<:Union{MultipliedOperator{D}, D} where {D<:DerivativeOperator}})(y) = sum(O -> O(y), x)
+Base.:*(h::LazySum{<:Union{D,MultipliedOperator{D}} where {D<:DerivativeOperator}}, v)  = h(v)
 
 function ∂∂C(pos::Int, mps, opp::MultipliedOperator, cache)
     return MultipliedOperator(∂∂C(pos::Int, mps, opp.op, cache), opp.f)

--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -177,6 +177,12 @@ function expectation_value(ψ::FiniteQP, O::MPOHamiltonian)
     return expectation_value(convert(FiniteMPS, ψ), O)
 end
 
+# more specific typing to account for onsite operators, array of operators, ...
+# define expectation_value for MultipliedOperator as scalar multiplication of the non-multiplied result, instead of multiplying the operator itself
+function expectation_value(ψ, op::UntimedOperator, args...)
+    return op.f * expectation_value(ψ, op.op, args...)
+end
+
 # define expectation_value for LazySum
 function expectation_value(ψ, ops::LazySum, at::Int)
     return sum(op -> expectation_value(ψ, op, at), ops)

--- a/src/algorithms/timestep/integrators.jl
+++ b/src/algorithms/timestep/integrators.jl
@@ -1,0 +1,24 @@
+"""
+    integrate(f, y₀, t, dt, alg)
+
+Integrate the differential equation ``i dy/dt = f(y, t)`` over a time step 'dt' starting from
+``y(t₀)=y₀``, using the provided algorithm.
+
+# Arguments
+- `f`: driving function
+- `y₀`: object to integrate
+- `t::Number`: starting time of time-step
+- `dt::Number`: time-step magnitude
+- `alg`: integration scheme
+"""
+function integrate end
+
+# default for things that are callable on two arguments
+_eval_t(f, t::Number) = Base.Fix2(f, t)
+_eval_x(f, x)         = Base.Fix1(f, x)
+
+function integrate(f, y₀, t::Number, dt::Number, alg::Union{Arnoldi,Lanczos})
+    y, convhist = exponentiate(_eval_t(f, t), -1im*dt, y₀, alg)
+    convhist.converged == 0 && @warn "integration failed $(convhist.normres)"
+    return y
+end

--- a/src/algorithms/timestep/tdvp.jl
+++ b/src/algorithms/timestep/tdvp.jl
@@ -1,91 +1,105 @@
 """
-    timestep(ψ, H, dt, algorithm, environments)
-    timestep!(ψ, H, dt, algorithm, environments)
-
-Compute the time-evolved state ``ψ′ ≈ exp(-iHdt) ψ``.
-
-# Arguments
-- `ψ::AbstractMPS`: current state
-- `H::AbstractMPO`: evolution operator
-- `dt::Number`: timestep
-- `algorithm`: evolution algorithm
-- `[environments]`: environment manager
-"""
-function timestep end, function timestep! end
-
-"""
     TDVP{A} <: Algorithm
 
 Single site [TDVP](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.107.070601)
 algorithm for time evolution.
 
 # Fields
-- `expalg::A`: exponentiator algorithm
+- `integrator::A`: integration algorithm (defaults to Lanczos exponentiation)
 - `tolgauge::Float64`: tolerance for gauging algorithm
-- `maxiter::Int`: maximum amount of gauging iterations
+- `gaugemaxiter::Int`: maximum amount of gauging iterations
+- `finalize::F`: user-supplied function which is applied after each timestep, with
+    signature `finalize(t, Ψ, H, envs) -> Ψ, envs`
 """
-@kwdef struct TDVP{A} <: Algorithm
-    expalg::A = Lanczos(; tol=Defaults.tol)
+@kwdef struct TDVP{A,F} <: Algorithm
+    integrator::A = Lanczos(; tol=Defaults.tol)
     tolgauge::Float64 = Defaults.tolgauge
-    maxiter::Int = Defaults.maxiter
+    gaugemaxiter::Int = Defaults.maxiter
+    finalize::F = Defaults._finalize
 end
 
-function timestep(ψ::InfiniteMPS, H, dt::Number, alg::TDVP, envs::Cache=environments(ψ, H))
-    temp_ACs = similar(ψ.AC)
-    temp_CRs = similar(ψ.CR)
-
-    @sync for (loc, (ac, c)) in enumerate(zip(ψ.AC, ψ.CR))
+function timestep(
+    Ψ::InfiniteMPS,
+    H,
+    t::Number,
+    dt::Number,
+    alg::TDVP,
+    envs::Union{Cache,MultipleEnvironments}=environments(Ψ, H);
+    leftorthflag=true,
+)
+    temp_ACs = similar(Ψ.AC)
+    temp_CRs = similar(Ψ.CR)
+    @sync for (loc, (ac, c)) in enumerate(zip(Ψ.AC, Ψ.CR))
         Threads.@spawn begin
-            h = ∂∂AC($loc, $ψ, $H, $envs)
-            $temp_ACs[loc], convhist = exponentiate(h, -1im * $dt, $ac, alg.expalg)
-            convhist.converged == 0 &&
-                @info "time evolving ac($loc) failed $(convhist.normres)"
+            h_ac = ∂∂AC(loc, Ψ, H, envs)
+            temp_ACs[loc] = integrate(h_ac, ac, t, dt, alg.integrator)
         end
 
         Threads.@spawn begin
-            h = ∂∂C($loc, $ψ, $H, $envs)
-            $temp_CRs[loc], convhist = exponentiate(h, -1im * $dt, $c, alg.expalg)
-            convhist.converged == 0 &&
-                @info "time evolving a($loc) failed $(convhist.normres)"
+            h_c = ∂∂C(loc, Ψ, H, envs)
+            temp_CRs[loc] = integrate(h_c, c, t, dt, alg.integrator)
         end
     end
 
-    for loc in 1:length(ψ)
+    if leftorthflag
+        for loc in 1:length(Ψ)
+            # find AL that best fits these new Acenter and centers
+            QAc, _ = leftorth!(temp_ACs[loc]; alg=TensorKit.QRpos())
+            Qc, _ = leftorth!(temp_CRs[loc]; alg=TensorKit.QRpos())
+            @plansor temp_ACs[loc][-1 -2; -3] = QAc[-1 -2; 1] * conj(Qc[-3; 1])
+        end
+        newΨ = InfiniteMPS(temp_ACs, Ψ.CR[end]; tol=alg.tolgauge, maxiter=alg.gaugemaxiter)
 
-        #find Al that best fits these new Acenter and centers
-        QAc, _ = leftorth!(temp_ACs[loc]; alg=TensorKit.QRpos())
-        Qc, _ = leftorth!(temp_CRs[loc]; alg=TensorKit.QRpos())
-        @plansor temp_ACs[loc][-1 -2; -3] = QAc[-1 -2; 1] * conj(Qc[-3; 1])
+    else
+        for loc in 1:length(Ψ)
+            # find AR that best fits these new Acenter and centers
+            _, QAc = rightorth!(_transpose_tail(temp_ACs[loc]); alg=TensorKit.LQpos())
+            _, Qc = rightorth!(temp_CRs[mod1(loc - 1, end)]; alg=TensorKit.LQpos())
+            temp_ACs[loc] = _transpose_front(Qc' * QAc)
+        end
+        newΨ = InfiniteMPS(Ψ.CR[0], temp_ACs; tol=alg.tolgauge, maxiter=alg.gaugemaxiter)
     end
 
-    nstate = InfiniteMPS(temp_ACs, ψ.CR[end]; tol=alg.tolgauge, maxiter=alg.maxiter)
-    recalculate!(envs, nstate)
-    return nstate, envs
+    recalculate!(envs, newΨ)
+    return newΨ, envs
 end
 
-function timestep!(ψ::AbstractFiniteMPS, H, dt::Number, alg::TDVP, envs=environments(ψ, H))
-    for i in 1:(length(ψ) - 1)
-        h_ac = ∂∂AC(i, ψ, H, envs)
-        ψ.AC[i], convhist = exponentiate(h_ac, -1im * dt / 2, ψ.AC[i], alg.expalg)
+function timestep!(
+    Ψ::AbstractFiniteMPS,
+    H,
+    t::Number,
+    dt::Number,
+    alg::TDVP,
+    envs::Union{Cache,MultipleEnvironments}=environments(Ψ, H),
+)
 
-        h_c = ∂∂C(i, ψ, H, envs)
-        ψ.CR[i], convhist = exponentiate(h_c, 1im * dt / 2, ψ.CR[i], alg.expalg)
+    # sweep left to right
+    for i in 1:(length(Ψ) - 1)
+        h_ac = ∂∂AC(i, Ψ, H, envs)
+        Ψ.AC[i] = integrate(h_ac, Ψ.AC[i], t, dt / 2, alg.integrator)
+
+        h_c = ∂∂C(i, Ψ, H, envs)
+        Ψ.CR[i] = integrate(h_c, Ψ.CR[i], t, -dt / 2, alg.integrator)
     end
 
-    h_ac = ∂∂AC(length(ψ), ψ, H, envs)
-    ψ.AC[end], convhist = exponentiate(h_ac, -1im * dt / 2, ψ.AC[end], alg.expalg)
+    # edge case
+    h_ac = ∂∂AC(length(Ψ), Ψ, H, envs)
+    Ψ.AC[end] = integrate(h_ac, Ψ.AC[end], t, dt / 2, alg.integrator)
 
-    for i in length(ψ):-1:2
-        h_ac = ∂∂AC(i, ψ, H, envs)
-        ψ.AC[i], convhist = exponentiate(h_ac, -1im * dt / 2, ψ.AC[i], alg.expalg)
+    # sweep right to left
+    for i in length(Ψ):-1:2
+        h_ac = ∂∂AC(i, Ψ, H, envs)
+        Ψ.AC[i] = integrate(h_ac, Ψ.AC[i], t + dt / 2, dt / 2, alg.integrator)
 
-        h_c = ∂∂C(i - 1, ψ, H, envs)
-        ψ.CR[i - 1], convhist = exponentiate(h_c, 1im * dt / 2, ψ.CR[i - 1], alg.expalg)
+        h_c = ∂∂C(i - 1, Ψ, H, envs)
+        Ψ.CR[i - 1] = integrate(h_c, Ψ.CR[i - 1], t + dt / 2, -dt / 2, alg.integrator)
     end
 
-    h_ac = ∂∂AC(1, ψ, H, envs)
-    ψ.AC[1], convhist = exponentiate(h_ac, -1im * dt / 2, ψ.AC[1], alg.expalg)
-    return ψ, envs
+    # edge case
+    h_ac = ∂∂AC(1, Ψ, H, envs)
+    Ψ.AC[1] = integrate(h_ac, Ψ.AC[1], t + dt / 2, dt / 2, alg.integrator)
+
+    return Ψ, envs
 end
 
 """
@@ -95,61 +109,71 @@ end
 algorithm for time evolution.
 
 # Fields
-- `expalg::A`: exponentiator algorithm
+- `integrator::A`: integrator algorithm (defaults to Lanczos exponentiation)
 - `tolgauge::Float64`: tolerance for gauging algorithm
-- `maxiter::Int`: maximum amount of gauging iterations
+- `gaugemaxiter::Int`: maximum amount of gauging iterations
 - `trscheme`: truncation algorithm for [tsvd][TensorKit.tsvd](@ref)
+- `finalize::F`: user-supplied function which is applied after each timestep, with
+    signature `finalize(t, Ψ, H, envs) -> Ψ, envs`
 """
-@kwdef struct TDVP2{A} <: Algorithm
-    expalg::A = Lanczos(; tol=Defaults.tol)
+@kwdef struct TDVP2{A,F} <: Algorithm
+    integrator::A = Lanczos(; tol=Defaults.tol)
     tolgauge::Float64 = Defaults.tolgauge
-    maxiter::Int = Defaults.maxiter
+    gaugemaxiter::Int = Defaults.maxiter
     trscheme = truncerr(1e-3)
+    finalize::F = Defaults._finalize
 end
 
-function timestep!(ψ::AbstractFiniteMPS, H, dt::Number, alg::TDVP2, envs=environments(ψ, H);
-                   rightorthed=false)
-    #left to right
-    for i in 1:(length(ψ) - 1)
-        ac2 = _transpose_front(ψ.AC[i]) * _transpose_tail(ψ.AR[i + 1])
+function timestep!(
+    Ψ::AbstractFiniteMPS, H, t::Number, dt::Number, alg::TDVP2, envs=environments(Ψ, H)
+)
 
-        h_ac2 = ∂∂AC2(i, ψ, H, envs)
-        nac2, convhist = exponentiate(h_ac2, -1im * dt / 2, ac2, alg.expalg)
+    # sweep left to right
+    for i in 1:(length(Ψ) - 1)
+        ac2 = _transpose_front(Ψ.AC[i]) * _transpose_tail(Ψ.AR[i + 1])
+        h_ac2 = ∂∂AC2(i, Ψ, H, envs)
+        nac2 = integrate(h_ac2, ac2, t, dt / 2, alg.integrator)
 
-        nal, nc, nar = tsvd(nac2; trunc=alg.trscheme, alg=TensorKit.SVD())
+        nal, nc, nar = tsvd!(nac2; trunc=alg.trscheme, alg=TensorKit.SVD())
+        Ψ.AC[i] = (nal, complex(nc))
+        Ψ.AC[i + 1] = (complex(nc), _transpose_front(nar))
 
-        ψ.AC[i] = (nal, complex(nc))
-        ψ.AC[i + 1] = (complex(nc), _transpose_front(nar))
-
-        if i != (length(ψ) - 1)
-            ψ.AC[i + 1], convhist = exponentiate(∂∂AC(i + 1, ψ, H, envs), 1im * dt / 2,
-                                                 ψ.AC[i + 1], alg.expalg)
+        if i != (length(Ψ) - 1)
+            Ψ.AC[i + 1] = integrate(
+                ∂∂AC(i + 1, Ψ, H, envs), Ψ.AC[i + 1], t, -dt / 2, alg.integrator
+            )
         end
     end
 
-    #right to left
-    for i in length(ψ):-1:2
-        ac2 = _transpose_front(ψ.AL[i - 1]) * _transpose_tail(ψ.AC[i])
+    # sweep right to left
+    for i in length(Ψ):-1:2
+        ac2 = _transpose_front(Ψ.AL[i - 1]) * _transpose_tail(Ψ.AC[i])
+        h_ac2 = ∂∂AC2(i - 1, Ψ, H, envs)
+        nac2 = integrate(h_ac2, ac2, t + dt / 2,  dt / 2, alg.integrator)
 
-        h_ac2 = ∂∂AC2(i - 1, ψ, H, envs)
-        (nac2, convhist) = exponentiate(h_ac2, -1im * dt / 2, ac2, alg.expalg)
-
-        nal, nc, nar = tsvd(nac2; trunc=alg.trscheme, alg=TensorKit.SVD())
-
-        ψ.AC[i - 1] = (nal, complex(nc))
-        ψ.AC[i] = (complex(nc), _transpose_front(nar))
+        nal, nc, nar = tsvd!(nac2; trunc=alg.trscheme, alg=TensorKit.SVD())
+        Ψ.AC[i - 1] = (nal, complex(nc))
+        Ψ.AC[i] = (complex(nc), _transpose_front(nar))
 
         if i != 2
-            ψ.AC[i - 1], convhist = exponentiate(∂∂AC(i - 1, ψ, H, envs), 1im * dt / 2,
-                                                 ψ.AC[i - 1], alg.expalg)
+            Ψ.AC[i - 1] = integrate(
+                ∂∂AC(i - 1, Ψ, H, envs), Ψ.AC[i - 1], t + dt / 2,  -dt / 2, alg.integrator
+            )
         end
     end
 
-    return ψ, envs
+    return Ψ, envs
 end
 
 #copying version
-function timestep(ψ::AbstractFiniteMPS, H, timestep, alg::Union{TDVP,TDVP2},
-                  envs=environments(ψ, H))
-    return timestep!(copy(ψ), H, timestep, alg, envs)
+function timestep(
+    Ψ::AbstractFiniteMPS,
+    H,
+    time::Number,
+    timestep::Number,
+    alg::Union{TDVP,TDVP2},
+    envs=environments(Ψ, H);
+    kwargs...,
+)
+    return timestep!(copy(Ψ), H, time, timestep, alg, envs; kwargs...)
 end

--- a/src/algorithms/timestep/time_evolve.jl
+++ b/src/algorithms/timestep/time_evolve.jl
@@ -1,0 +1,54 @@
+"""
+    time_evolve(ψ₀, H, t_span, [alg], [envs]; kwargs...)
+    time_evolve!(ψ₀, H, t_span, [alg], [envs]; kwargs...)
+
+Time-evolve the initial state `ψ₀` with Hamiltonian `H` over a given time span by stepping
+through each of the time points obtained by iterating t_span.
+
+# Arguments
+- `ψ₀::AbstractMPS`: initial state
+- `H::AbstractMPO`: operator that generates the time evolution (can be time-dependent).
+- `t_span::AbstractVector{<:Number}`: time points over which the time evolution is stepped
+- `[alg]`: algorithm to use for the time evolution. Defaults to [`TDVP`](@ref).
+- `[envs]`: MPS environment manager
+"""
+function time_evolve end, function time_evolve! end
+
+# TODO: is it possible to remove this code-duplication?
+function time_evolve(
+    ψ, H, t_span::AbstractVector{<:Number}, alg, envs=environments(Ψ₀, H); verbose=false
+)
+    for (t, dt) in zip(t_span[2:end], diff(t_span))
+        elapsed = @elapsed ψ, envs = timestep(ψ, H, t, dt, alg, envs)
+        verbose && @info "Timestep iteration:" t elapsed
+        ψ, envs = alg.finalize(t, ψ, H, envs)::Tuple{typeof(ψ),typeof(envs)}
+    end
+    return ψ, envs
+end
+function time_evolve!(
+    ψ, H, t_span::AbstractVector{<:Number}, alg, envs=environments(Ψ₀, H); verbose=false
+)
+    for (t, dt) in zip(t_span[2:end], diff(t_span))
+        elapsed = @elapsed ψ, envs = timestep!(ψ, H, t, dt, alg, envs)
+        verbose && @info "Timestep iteration:" t elapsed
+        ψ, envs = alg.finalize(t, ψ, H, envs)::Tuple{typeof(ψ),typeof(envs)}
+    end
+    return ψ, envs
+end
+
+"""
+    timestep(ψ₀, H, t, dt, [alg], [envs]; kwargs...)
+    timestep!(ψ₀, H, t, dt, [alg], [envs]; kwargs...)
+
+Time-step the state `ψ₀` with Hamiltonian `H` over a given time step `dt` at time `t`,
+solving the Schroedinger equation: ``i ∂ψ/∂t = H ψ``.
+
+# Arguments
+- `ψ₀::AbstractMPS`: initial state
+- `H::AbstractMPO`: operator that generates the time evolution (can be time-dependent).
+- `t::Number`: starting time of time-step
+- `dt::Number`: time-step magnitude
+- `[alg]`: algorithm to use for the time evolution. Defaults to [`TDVP`](@ref).
+- `[envs]`: MPS environment manager
+"""
+function timestep end, function timestep! end

--- a/src/algorithms/timestep/time_evolve.jl
+++ b/src/algorithms/timestep/time_evolve.jl
@@ -16,7 +16,7 @@ function time_evolve end, function time_evolve! end
 
 # TODO: is it possible to remove this code-duplication?
 function time_evolve(
-    ψ, H, t_span::AbstractVector{<:Number}, alg, envs=environments(Ψ₀, H); verbose=false
+    ψ, H, t_span::AbstractVector{<:Number}, alg, envs=environments(ψ, H); verbose=false
 )
     for (t, dt) in zip(t_span[2:end], diff(t_span))
         elapsed = @elapsed ψ, envs = timestep(ψ, H, t, dt, alg, envs)
@@ -26,7 +26,7 @@ function time_evolve(
     return ψ, envs
 end
 function time_evolve!(
-    ψ, H, t_span::AbstractVector{<:Number}, alg, envs=environments(Ψ₀, H); verbose=false
+    ψ, H, t_span::AbstractVector{<:Number}, alg, envs=environments(ψ, H); verbose=false
 )
     for (t, dt) in zip(t_span[2:end], diff(t_span))
         elapsed = @elapsed ψ, envs = timestep!(ψ, H, t, dt, alg, envs)

--- a/src/operators/lazysum.jl
+++ b/src/operators/lazysum.jl
@@ -54,5 +54,6 @@ end
 
 Base.:+(op1::LazySum, op2) = op1 + LazySum(op2)
 Base.:+(op1, op2::LazySum) = LazySum(op1) + op2
+Base.:+(op1::MultipliedOperator, op2::MultipliedOperator) = LazySum([op1,op2])
 
 Base.repeat(x::LazySum, args...) = LazySum(repeat.(x, args...))

--- a/src/operators/lazysum.jl
+++ b/src/operators/lazysum.jl
@@ -17,45 +17,33 @@ struct LazySum{O} <: AbstractVector{O}
     ops::Vector{O}
 end
 
+# for the AbstractArray interface
 Base.size(x::LazySum) = size(x.ops)
 Base.getindex(x::LazySum, i) = x.ops[i]
-#iteration and summation gets automatically implementend thanks to subtyping
-
 Base.length(x::LazySum) = prod(size(x))
 Base.similar(x::LazySum, ::Type{S}, dims::Dims) where {S} = LazySum(similar(x.ops, S, dims))
 
 # Holy traits
-struct TimeDependent end
-struct NotTimeDependent end
-
-TimeDependence(x) = NotTimeDependent()
 TimeDependence(x::LazySum) = istimed(x) ? TimeDependent() : NotTimeDependent()
-
-istimed(::TimeDependent) = true
-istimed(::NotTimeDependent) = false
-istimed(x) = istimed(TimeDependence(x))
 istimed(x::LazySum) = any(istimed, x)
 
 # constructors
 LazySum(x) = LazySum([x])
 LazySum(f::Function, x) = LazySum(map(y -> f(y), x))
 
-# Internal use only, works always
-_eval_at(x, args...) = x # -> this is what you should define for your custom structs inside a LazySum
-
-# wrapper around _eval_at
-eval_at(x, args...) = eval_at(TimeDependence(x), x, args...)
-eval_at(::TimeDependent, x::LazySum, t::Number) = LazySum(O -> _eval_at(O, t), x)
-function eval_at(::TimeDependent, x::LazySum)
+# wrapper around unsafe_eval
+safe_eval(::TimeDependent, x::LazySum, t::Number) = LazySum(O -> unsafe_eval(O, t), x)
+function safe_eval(::TimeDependent, x::LazySum)
     throw(ArgumentError("attempting to evaluate time-dependent LazySum without specifiying a time"))
 end
-eval_at(::NotTimeDependent, x::LazySum) = sum(O -> _eval_at(O), x)
-function eval_at(::NotTimeDependent, x::LazySum, t::Number)
+safe_eval(::NotTimeDependent, x::LazySum) = sum(O -> unsafe_eval(O), x)
+function safe_eval(::NotTimeDependent, x::LazySum, t::Number)
     throw(ArgumentError("attempting to evaluate time-independent LazySum at time"))
 end
 
 # For users
-(x::LazySum)(t::Number) = eval_at(x, t) # using (t) should return NotTimeDependent LazySum
+# using (t) should return NotTimeDependent LazySum
+(x::LazySum)(::,t::Number) = safe_eval(x, t) 
 
 # we define the addition for LazySum and we do the rest with this
 function Base.:+(SumOfOps1::LazySum, SumOfOps2::LazySum)

--- a/src/operators/lazysum.jl
+++ b/src/operators/lazysum.jl
@@ -31,19 +31,19 @@ istimed(x::LazySum) = any(istimed, x)
 LazySum(x) = LazySum([x])
 LazySum(f::Function, x) = LazySum(map(y -> f(y), x))
 
-# wrapper around unsafe_eval
-safe_eval(::TimeDependent, x::LazySum, t::Number) = LazySum(O -> unsafe_eval(O, t), x)
+# wrapper around _eval_at
+safe_eval(::TimeDependent, x::LazySum, t::Number) = LazySum(O -> _eval_at(O, t), x)
 function safe_eval(::TimeDependent, x::LazySum)
     throw(ArgumentError("attempting to evaluate time-dependent LazySum without specifiying a time"))
 end
-safe_eval(::NotTimeDependent, x::LazySum) = sum(O -> unsafe_eval(O), x)
+safe_eval(::NotTimeDependent, x::LazySum) = sum(O -> _eval_at(O), x)
 function safe_eval(::NotTimeDependent, x::LazySum, t::Number)
     throw(ArgumentError("attempting to evaluate time-independent LazySum at time"))
 end
 
 # For users
 # using (t) should return NotTimeDependent LazySum
-(x::LazySum)(::,t::Number) = safe_eval(x, t) 
+(x::LazySum)(t::Number) = safe_eval(x, t) 
 
 # we define the addition for LazySum and we do the rest with this
 function Base.:+(SumOfOps1::LazySum, SumOfOps2::LazySum)

--- a/src/operators/multipliedoperator.jl
+++ b/src/operators/multipliedoperator.jl
@@ -1,0 +1,53 @@
+"""
+    Structure representing a multiplied operator. Consists of
+        - An operator op (MPO, Hamiltonian, ...)
+        - An object f that gets multiplied with the operator (Number, function, ...) 
+"""
+struct MultipliedOperator{O,F}
+    op::O
+    f::F
+end
+
+"""
+    Structure representing a time-dependent operator. Consists of
+        - An operator op (MPO, Hamiltonian, ...)
+        - An function f that gives the time-dependence according to op(t) = f(t)*op
+"""
+const TimedOperator{O} = MultipliedOperator{O,<:Function}
+
+"""
+    Structure representing a time-independent operator that will be multiplied with a constant coefficient. Consists of
+        - An operator (MPO, Hamiltonian, ...)
+        - A number f that gets multiplied with the operator
+"""
+const UntimedOperator{O} = MultipliedOperator{O,<:Union{Real,One}}
+
+#constructors for (un)TimedOperator
+TimedOperator(x::O, f::F) where {F<:Function,O} = MultipliedOperator(x, f)
+UntimedOperator(x::O, c::C) where {C<:Union{Real,One},O} = MultipliedOperator(x, c)
+
+TimedOperator(x) = TimedOperator(x,t->One())
+UntimedOperator(x) = UntimedOperator(x,One())
+
+# For internal use only
+unsafe_eval(x::UntimedOperator) = x.f * x.op
+unsafe_eval(x::UntimedOperator, ::Number) = unsafe_eval(x)
+unsafe_eval(x::TimedOperator, t::Number) = UntimedOperator(x.op,x.f(t))
+
+# For users
+(x::UntimedOperator)()  = unsafe_eval(x)
+(x::TimedOperator)(t::Number)  = unsafe_eval(x,t)
+
+# what to do when we multiply by a scalar
+Base.:*(op::UntimedOperator, b::Number) = UntimedOperator(op.op, b * op.f)
+Base.:*(op::TimedOperator, b::Number)   = TimedOperator(op.op, t -> b * op.f(t))
+Base.:*(b::Number, op::MultipliedOperator) = op * b
+
+Base.:*(op::TimedOperator, g::Function) = TimedOperator(op.op, t -> g(t) * op.f(t)) #slightly dangerous
+Base.:*(g::Function, op::TimedOperator) = op * g
+
+# don't know a better place to put this
+# environment for MultipliedOperator
+function environments(st, x::MultipliedOperator, args...; kwargs...)
+    return environments(st, x.op, args...; kwargs...)
+end

--- a/src/operators/multipliedoperator.jl
+++ b/src/operators/multipliedoperator.jl
@@ -34,7 +34,7 @@ TimeDependence(x::TimedOperator) = TimeDependent()
 
 # For internal use only
 _eval_at(x::UntimedOperator) = x.f * x.op
-_eval_at(x::UntimedOperator, ::Number) = _eval_at(x)
+_eval_at(x::UntimedOperator, ::Number) = x #_eval_at(x)
 _eval_at(x::TimedOperator, t::Number) = UntimedOperator(x.op,x.f(t))
 
 # For users

--- a/src/operators/multipliedoperator.jl
+++ b/src/operators/multipliedoperator.jl
@@ -29,6 +29,9 @@ UntimedOperator(x::O, c::C) where {C<:Union{Real,One},O} = MultipliedOperator(x,
 TimedOperator(x) = TimedOperator(x,t->One())
 UntimedOperator(x) = UntimedOperator(x,One())
 
+# Holy traits
+TimeDependence(x::TimedOperator) = TimeDependent()
+
 # For internal use only
 _eval_at(x::UntimedOperator) = x.f * x.op
 _eval_at(x::UntimedOperator, ::Number) = _eval_at(x)

--- a/src/operators/multipliedoperator.jl
+++ b/src/operators/multipliedoperator.jl
@@ -30,13 +30,13 @@ TimedOperator(x) = TimedOperator(x,t->One())
 UntimedOperator(x) = UntimedOperator(x,One())
 
 # For internal use only
-unsafe_eval(x::UntimedOperator) = x.f * x.op
-unsafe_eval(x::UntimedOperator, ::Number) = unsafe_eval(x)
-unsafe_eval(x::TimedOperator, t::Number) = UntimedOperator(x.op,x.f(t))
+_eval_at(x::UntimedOperator) = x.f * x.op
+_eval_at(x::UntimedOperator, ::Number) = _eval_at(x)
+_eval_at(x::TimedOperator, t::Number) = UntimedOperator(x.op,x.f(t))
 
 # For users
-(x::UntimedOperator)()  = unsafe_eval(x)
-(x::TimedOperator)(t::Number)  = unsafe_eval(x,t)
+(x::UntimedOperator)()  = _eval_at(x)
+(x::TimedOperator)(t::Number)  = _eval_at(x,t)
 
 # what to do when we multiply by a scalar
 Base.:*(op::UntimedOperator, b::Number) = UntimedOperator(op.op, b * op.f)

--- a/src/operators/timedependence.jl
+++ b/src/operators/timedependence.jl
@@ -11,4 +11,4 @@ istimed(x) = istimed(TimeDependence(x))
 safe_eval(x, args...) = safe_eval(TimeDependence(x), x, args...)
 
 # Internal use only, works always
-unsafe_eval(x, args...) = x # -> this is what you should define for custom structs
+_eval_at(x, args...) = x # -> this is what you should define for custom structs

--- a/src/operators/timedependence.jl
+++ b/src/operators/timedependence.jl
@@ -1,0 +1,14 @@
+# Holy traits to differentiate between time dependent and time independent types
+
+struct TimeDependent end
+struct NotTimeDependent end
+
+TimeDependence(x) = NotTimeDependent()
+istimed(::TimeDependent) = true
+istimed(::NotTimeDependent) = false
+istimed(x) = istimed(TimeDependence(x))
+
+safe_eval(x, args...) = safe_eval(TimeDependence(x), x, args...)
+
+# Internal use only, works always
+unsafe_eval(x, args...) = x # -> this is what you should define for custom structs

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -106,6 +106,14 @@ function InfiniteMPS(AL::AbstractVector{<:GenericMPSTensor}, C₀::MPSBondTensor
     return InfiniteMPS(AL, AR, CR)
 end
 
+function InfiniteMPS(C₀::MPSBondTensor, AR::AbstractVector{<:GenericMPSTensor}; kwargs...)
+    CR = PeriodicArray(fill(copy(C₀), length(AR)))
+    AR = PeriodicArray(copy.(AR))
+    AL = similar(AR)
+    uniform_leftorth!(AL, CR, AR; kwargs...)
+    return InfiniteMPS(AL, AR, CR)
+end
+
 #===========================================================================================
 Utility
 ===========================================================================================#

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -91,6 +91,57 @@ end
     @test sum(LazyOs_added) ≈ 2 * summed atol = 1 - 08
 end
 
+@testset "MulitpliedOperator of $(typeof(O)) with $(typeof(f))" for (O,f) in zip((rand(ComplexF64),
+                                                    TensorMap(rand, ComplexF64,
+                                                                    ℂ^13, ℂ^7),
+                                                    TensorMap(rand, ComplexF64,
+                                                                    ℂ^1 ⊗ ℂ^2,
+                                                                    ℂ^3 ⊗ ℂ^4),
+                                                        ),(t->3t,1.1,One()))
+
+    tmp = MPSKit.MultipliedOperator(O,f)
+    if tmp isa TimedOperator
+        @test tmp(1.1)() ≈ f(1.1)*O atol = 1 - 08
+    elseif tmp isa UntimedOperator
+        @test tmp() ≈ f*O atol = 1 - 08
+    end
+end
+
+@testset "General Time-dependent LazySum of $(eltype(Os))" for Os in (rand(ComplexF64, 4),
+                                                    fill(TensorMap(rand, ComplexF64,
+                                                                    ℂ^13, ℂ^7),
+                                                        4),
+                                                    fill(TensorMap(rand, ComplexF64,
+                                                                    ℂ^1 ⊗ ℂ^2,
+                                                                    ℂ^3 ⊗ ℂ^4),
+                                                        4))
+    
+    
+    #test user interface
+    fs     = [t->3t,t->t+2,4,1]
+    Ofs = map(zip(fs,Os)) do (f,O)
+        if f == 1
+            return O
+        else
+            return MPSKit.MultipliedOperator(O,f)
+        end
+    end
+    LazyOs = LazySum(Ofs) 
+    summed = sum(zip(fs,Os)) do (f,O)
+        if f isa Function
+            f(1.1)*O
+        else
+            f*O
+        end
+    end
+
+    @test sum(LazyOs(1.1)) ≈ summed atol = 1 - 08
+
+    LazyOs_added = +(LazyOs, Ofs...)
+
+    @test sum(LazyOs_added(1.1)) ≈ 2 * summed atol = 1 - 08
+end
+
 @testset "DenseMPO" for ham in (transverse_field_ising(), heisenberg_XXX(; spin=1))
     physical_space = ham.pspaces[1]
     ou = oneunit(physical_space)
@@ -144,19 +195,73 @@ vspaces = (ℙ^10, Rep[U₁]((0 => 20)), Rep[SU₂](1 => 10, 3 => 5, 5 => 1))
         sum1 = sum(zip(Hs, Envs)) do (H, env)
             return MPSKit.∂∂C(1, ψ, H, env)(ψ.CR[1])
         end
-        @test summedhct(ψ.CR[1]) ≈ sum1
+        @test summedhct(ψ.CR[1], 0.) ≈ sum1
 
         summedhct = MPSKit.∂∂AC(1, ψ, summedH, summedEnvs)
         sum2 = sum(zip(Hs, Envs)) do (H, env)
             return MPSKit.∂∂AC(1, ψ, H, env)(ψ.AC[1])
         end
-        @test summedhct(ψ.AC[1]) ≈ sum2
+        @test summedhct(ψ.AC[1], 0.) ≈ sum2
 
         v = MPSKit._transpose_front(ψ.AC[1]) * MPSKit._transpose_tail(ψ.AR[2])
         summedhct = MPSKit.∂∂AC2(1, ψ, summedH, summedEnvs)
         sum3 = sum(zip(Hs, Envs)) do (H, env)
             return MPSKit.∂∂AC2(1, ψ, H, env)(v)
         end
-        @test summedhct(v) ≈ sum3
+        @test summedhct(v, 0.) ≈ sum3
+    end
+
+    fs = [t->3t,2,1]
+    Hts = [TimedOperator(H1,fs[1]),UntimedOperator(H2,fs[2]),H3]
+    summedH = LazySum(Hts)
+    t = 1.1
+    summedH_at = summedH(t)
+
+    @testset "Time-dependent LazySum $(ψ isa FiniteMPS ? "F" : "Inf")initeMPS" for ψ in ψs
+        Envs = map(H -> environments(ψ, H), Hs)
+        summedEnvs = environments(ψ, summedH)
+        
+
+        expval = sum(zip(fs, Hs, Envs)) do (f, H, Env)
+            if f isa Function
+                f = f(t)
+            end
+            f*expectation_value(ψ, H, Env)
+        end
+        expval1 = expectation_value(ψ, sum(summedH_at))
+        expval2 = expectation_value(ψ, summedH_at, summedEnvs)
+        expval3 = expectation_value(ψ, summedH_at)
+        @test expval ≈ expval1
+        @test expval ≈ expval2
+        @test expval ≈ expval3
+
+        # test derivatives
+        summedhct = MPSKit.∂∂C(1, ψ, summedH, summedEnvs)
+        sum1 = sum(zip(fs, Hs, Envs)) do (f, H, env)
+            if f isa Function
+                f = f(t)
+            end
+            return f*MPSKit.∂∂C(1, ψ, H, env)(ψ.CR[1])
+        end
+        @test summedhct(ψ.CR[1], t) ≈ sum1
+
+        summedhct = MPSKit.∂∂AC(1, ψ, summedH, summedEnvs)
+        sum2 = sum(zip(fs, Hs, Envs)) do (f, H, env)
+            if f isa Function
+                f = f(t)
+            end
+            return f*MPSKit.∂∂AC(1, ψ, H, env)(ψ.AC[1])
+        end
+        @test summedhct(ψ.AC[1], t) ≈ sum2
+
+        v = MPSKit._transpose_front(ψ.AC[1]) * MPSKit._transpose_tail(ψ.AR[2])
+        summedhct = MPSKit.∂∂AC2(1, ψ, summedH, summedEnvs)
+        sum3 = sum(zip(fs, Hs, Envs)) do (f, H, env)
+            if f isa Function
+                f = f(t)
+            end
+            return f*MPSKit.∂∂AC2(1, ψ, H, env)(v)
+        end
+        @test summedhct(v, t) ≈ sum3
     end
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -6,6 +6,7 @@ using MPSKit
 using MPSKit: _transpose_tail, _transpose_front
 using TensorKit
 using TensorKit: PlanarTrivial, ℙ
+using VectorInterface: One
 
 # using TensorOperations
 

--- a/test/states.jl
+++ b/test/states.jl
@@ -133,8 +133,8 @@ end
     @test v2 < v1
     @test real(e2[2]) ≤ real(e1[2])
 
-    (window, envs) = timestep(window, ham, 0.1, TDVP2(), envs)
-    (window, envs) = timestep(window, ham, 0.1, TDVP(), envs)
+    (window, envs) = timestep(window, ham, 0.1, 0.0, TDVP2(), envs)
+    (window, envs) = timestep(window, ham, 0.1, 0.0, TDVP(), envs)
 
     e3 = expectation_value(window, ham)
 


### PR DESCRIPTION
Adds a new struct `MultipliedOperator `that represents an operator that gets multiplied lazily with another object. Particular subtypes are `TimedOperator` and `UntimedOperator` where the operator gets multiplied by a time-dependent function or a number respectively. The actual multiplication is only done when it is needed e.g. in expectation_value
or when the action of derivative operator is calculated. Works out of the box for VUMPS, GradientGrassmann or TDVP algorithms and with only minor additions also in combination with `LazySum`. A `time_evolve` function was also added that does multiple `timestep`'s and has a convenient finalize that allows for example the bond dimension to be expanded. Comments and suggestions?