### PR TITLE
Quasiparticle optimizations

### DIFF
--- a/src/algorithms/excitation/quasiparticleexcitation.jl
+++ b/src/algorithms/excitation/quasiparticleexcitation.jl
@@ -23,7 +23,7 @@ end
 
 function excitations(H, alg::QuasiparticleAnsatz, ϕ₀::InfiniteQP, lenvs, renvs;
                      num=1, solver=Defaults.linearsolver)
-    qp_envs(ϕ) = enϕironments(ϕ, H, lenvs, renvs; solver=solver)
+    qp_envs(ϕ) = environments(ϕ, H, lenvs, renvs; solver)
     E = effective_excitation_renormalization_energy(H, ϕ₀, lenvs, renvs)
     H_eff = @closure(ϕ -> effective_excitation_hamiltonian(H, ϕ, qp_envs(ϕ), E))
 

--- a/src/algorithms/excitation/quasiparticleexcitation.jl
+++ b/src/algorithms/excitation/quasiparticleexcitation.jl
@@ -130,7 +130,7 @@ function excitations(H, alg::QuasiparticleAnsatz, ϕ₀::FiniteQP,
                      renvs=ϕ₀.trivial ? lenvs : environments(ϕ₀.right_gs, H); num=1)
     qp_envs(ϕ) = environments(ϕ, H, lenvs, renvs)
     E = effective_excitation_renormalization_energy(H, ϕ₀, lenvs, renvs)
-    H_eff = @closure(ϕ -> effective_excitation_hamiltonian(H, ϕ, qp_ens(ϕ), E))
+    H_eff = @closure(ϕ -> effective_excitation_hamiltonian(H, ϕ, qp_envs(ϕ), E))
     Es, ϕs, convhist = eigsolve(H_eff, ϕ₀, num, :SR, alg.alg)
 
     convhist.converged < num && @warn "Quasiparticle didn't converge: $(convhist.normres)"
@@ -254,7 +254,6 @@ end
 function effective_excitation_hamiltonian(H::MPOMultiline, ϕ::Multiline{<:InfiniteQP},
                                           envs=environments(ϕ, H))
     ϕ′ = Multiline(similar.(ϕ.data))
-
     left_gs = ϕ.left_gs
     right_gs = ϕ.right_gs
 

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -196,41 +196,41 @@ end
         H = repeat(force_planar(heisenberg_XXX()), 2)
         ψ = InfiniteMPS([ℙ^3, ℙ^3], [ℙ^48, ℙ^48])
         ψ, envs, _ = find_groundstate(ψ, H; maxiter=400, verbose=false, tol=1e-11)
-        energies, Bs = excitations(H, QuasiparticleAnsatz(), Float64(pi), ψ, envs)
+        energies, ϕs = excitations(H, QuasiparticleAnsatz(), Float64(pi), ψ, envs)
         @test energies[1] ≈ 0.41047925 atol = 1e-4
-        @test variance(Bs[1], H) < 1e-8
+        @test variance(ϕs[1], H) < 1e-8
     end
     @testset "infinite (mpo)" begin
-        th = repeat(sixvertex(), 2)
+        H = repeat(sixvertex(), 2)
         ψ = InfiniteMPS([ℂ^2, ℂ^2], [ℂ^10, ℂ^10])
-        ψ, envs, _ = leading_boundary(ψ, th, VUMPS(; maxiter=400, verbose=false))
-        energies, Bs = excitations(th, QuasiparticleAnsatz(), [0.0, Float64(pi / 2)], ψ,
+        ψ, envs, _ = leading_boundary(ψ, H, VUMPS(; maxiter=400, verbose=false))
+        energies, ϕs = excitations(H, QuasiparticleAnsatz(), [0.0, Float64(pi / 2)], ψ,
                                    envs; verbose=false)
         @test abs(energies[1]) > abs(energies[2]) # has a minima at pi/2
     end
 
     @testset "finite" begin
         verbose = false
-        th = force_planar(transverse_field_ising())
+        H = force_planar(transverse_field_ising())
         ψ = InfiniteMPS([ℙ^2], [ℙ^10])
-        ψ, envs, _ = find_groundstate(ψ, th; maxiter=400, verbose, tol=1e-9)
-        energies, Bs = excitations(th, QuasiparticleAnsatz(), 0.0, ψ, envs)
+        ψ, envs, _ = find_groundstate(ψ, H; maxiter=400, verbose, tol=1e-9)
+        energies, ϕs = excitations(H, QuasiparticleAnsatz(), 0.0, ψ, envs)
         inf_en = energies[1]
 
         fin_en = map([20, 10]) do len
             ψ = FiniteMPS(rand, ComplexF64, len, ℙ^2, ℙ^15)
-            (ψ, envs, _) = find_groundstate(ψ, th; verbose)
+            (ψ, envs, _) = find_groundstate(ψ, H; verbose)
 
             #find energy with quasiparticle ansatz
-            energies_QP, Bs = excitations(th, QuasiparticleAnsatz(), ψ, envs)
-            @test variance(Bs[1], th) < 1e-6
+            energies_QP, ϕs = excitations(H, QuasiparticleAnsatz(), ψ, envs)
+            @test variance(ϕs[1], H) < 1e-6
 
             #find energy with normal dmrg
-            energies_dm, _ = excitations(th,
+            energies_dm, _ = excitations(H,
                                          FiniteExcited(;
                                                        gsalg=DMRG(; verbose,
                                                                   tol=1e-6)), ψ)
-            @test energies_dm[1] ≈ energies_QP[1] + sum(expectation_value(ψ, th, envs)) atol = 1e-4
+            @test energies_dm[1] ≈ energies_QP[1] + sum(expectation_value(ψ, H, envs)) atol = 1e-4
 
             return energies_QP[1]
         end

--- a/test/states.jl
+++ b/test/states.jl
@@ -143,7 +143,7 @@ end
 end
 
 @testset "Quasiparticle state" verbose = true begin
-    @testset "Finite" verbose = true for (th, D, d) in
+    @testset "Finite" verbose = true for (H, D, d) in
                                          [(force_planar(transverse_field_ising()), ℙ^10,
                                            ℙ^2),
                                           (heisenberg_XXX(SU2Irrep; spin=1),
@@ -152,24 +152,22 @@ end
         normalize!(ψ)
 
         #rand_quasiparticle is a private non-exported function
-        qst1 = MPSKit.LeftGaugedQP(rand, ψ)
-        qst2 = MPSKit.LeftGaugedQP(rand, ψ)
+        ϕ₁ = MPSKit.LeftGaugedQP(rand, ψ)
+        ϕ₂ = MPSKit.LeftGaugedQP(rand, ψ)
 
-        @test norm(axpy!(1, qst1, copy(qst2))) ≤ norm(qst1) + norm(qst2)
-        @test norm(qst1) * 3 ≈ norm(qst1 * 3)
+        @test norm(axpy!(1, ϕ₁, copy(ϕ₂))) ≤ norm(ϕ₁) + norm(ϕ₂)
+        @test norm(ϕ₁) * 3 ≈ norm(ϕ₁ * 3)
 
-        normalize!(qst1)
+        normalize!(ϕ₁)
 
-        qst1_f = convert(FiniteMPS, qst1)
-        qst2_f = convert(FiniteMPS, qst2)
+        ϕ₁_f = convert(FiniteMPS, ϕ₁)
+        ϕ₂_f = convert(FiniteMPS, ϕ₂)
 
-        ovl_f = dot(qst1_f, qst2_f)
-        ovl_q = dot(qst1, qst2)
-        @test ovl_f ≈ ovl_q atol = 1e-5
-        @test norm(qst1_f) ≈ norm(qst1) atol = 1e-5
+        @test dot(ϕ₁_f, ϕ₂_f) ≈ dot(ϕ₁, ϕ₂) atol = 1e-5
+        @test norm(ϕ₁_f) ≈ norm(ϕ₁) atol = 1e-5
 
-        ev_f = sum(expectation_value(qst1_f, th) - expectation_value(ψ, th))
-        ev_q = dot(qst1, effective_excitation_hamiltonian(th, qst1))
+        ev_f = sum(expectation_value(ϕ₁_f, H) - expectation_value(ψ, H))
+        ev_q = dot(ϕ₁, effective_excitation_hamiltonian(H, ϕ₁))
         @test ev_f ≈ ev_q atol = 1e-5
     end
 
@@ -181,14 +179,14 @@ end
         ψ = InfiniteMPS(fill(d, period), fill(D, period))
 
         #rand_quasiparticle is a private non-exported function
-        qst1 = MPSKit.LeftGaugedQP(rand, ψ)
-        qst2 = MPSKit.LeftGaugedQP(rand, ψ)
+        ϕ₁ = MPSKit.LeftGaugedQP(rand, ψ)
+        ϕ₂ = MPSKit.LeftGaugedQP(rand, ψ)
 
-        @test norm(axpy!(1, qst1, copy(qst2))) ≤ norm(qst1) + norm(qst2)
-        @test norm(qst1) * 3 ≈ norm(qst1 * 3)
+        @test norm(axpy!(1, ϕ₁, copy(ϕ₂))) ≤ norm(ϕ₁) + norm(ϕ₂)
+        @test norm(ϕ₁) * 3 ≈ norm(ϕ₁ * 3)
 
-        @test dot(qst1,
-                  convert(MPSKit.LeftGaugedQP, convert(MPSKit.RightGaugedQP, qst1))) ≈
-              dot(qst1, qst1) atol = 1e-10
+        @test dot(ϕ₁,
+                  convert(MPSKit.LeftGaugedQP, convert(MPSKit.RightGaugedQP, ϕ₁))) ≈
+              dot(ϕ₁, ϕ₁) atol = 1e-10
     end
 end


### PR DESCRIPTION
Some attempts at speeding up the quasiparticle algorithms:

- removes the computation of renormalization energy from the effective excitation hamiltonian, as this does not need to be recomputed
- adds multithreading over sites, similar to how groundstate algorithms work