### PR TITLE
refactor dynamic tolerances using `ThrottledTol` 

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -61,14 +61,16 @@ export transfer_left, transfer_right
 abstract type Algorithm end
 abstract type Cache end # cache "manages" environments
 
-include("utility/defaults.jl")
+# submodules
+include("utility/throttledtol.jl")
+using .ThrottledTols
 
+include("utility/defaults.jl")
 include("utility/periodicarray.jl")
 include("utility/multiline.jl")
 include("utility/utility.jl") # random utility functions
 include("utility/plotting.jl")
 include("utility/linearcombination.jl")
-include("utility/throttledtol.jl")
 
 # maybe we should introduce an abstract state type
 include("states/window.jl")

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -62,8 +62,8 @@ abstract type Algorithm end
 abstract type Cache end # cache "manages" environments
 
 # submodules
-include("utility/throttledtol.jl")
-using .ThrottledTols
+include("utility/dynamictols.jl")
+using .DynamicTols
 
 include("utility/defaults.jl")
 include("utility/periodicarray.jl")

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -57,6 +57,10 @@ export transfer_left, transfer_right
 @deprecate params(args...) environments(args...)
 @deprecate InfiniteMPO(args...) DenseMPO(args...)
 
+# Abstract type defs
+abstract type Algorithm end
+abstract type Cache end # cache "manages" environments
+
 include("utility/defaults.jl")
 
 include("utility/periodicarray.jl")
@@ -64,6 +68,7 @@ include("utility/multiline.jl")
 include("utility/utility.jl") # random utility functions
 include("utility/plotting.jl")
 include("utility/linearcombination.jl")
+include("utility/throttledtol.jl")
 
 # maybe we should introduce an abstract state type
 include("states/window.jl")
@@ -89,8 +94,6 @@ include("operators/lazysum.jl")
 include("transfermatrix/transfermatrix.jl")
 include("transfermatrix/transfer.jl")
 
-abstract type Cache end # cache "manages" environments
-
 include("environments/FinEnv.jl")
 include("environments/abstractinfenv.jl")
 include("environments/permpoinfenv.jl")
@@ -99,8 +102,6 @@ include("environments/qpenv.jl")
 include("environments/multipleenv.jl")
 include("environments/idmrgenv.jl")
 include("environments/lazylincocache.jl")
-
-abstract type Algorithm end
 
 include("algorithms/derivatives.jl")
 include("algorithms/expval.jl")

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -37,9 +37,9 @@ end
 
 function updatetols(alg::VUMPS, iter, ϵ)
     if alg.dynamical_tols
-        tol_eigs = between(alg.tol_min, ϵ * alg.eigs_tolfactor / sqrt(iter), alg.tol_max)
-        tol_envs = between(alg.tol_min, ϵ * alg.envs_tolfactor / sqrt(iter), alg.tol_max)
-        tol_gauge = between(alg.tol_min, ϵ * alg.gauge_tolfactor / sqrt(iter), alg.tol_max)
+        tol_eigs = clamp(ϵ * alg.eigs_tolfactor / sqrt(iter), alg.tol_min, alg.tol_max)
+        tol_envs = clamp(ϵ * alg.envs_tolfactor / sqrt(iter), alg.tol_min, alg.tol_max)
+        tol_gauge = clamp(ϵ * alg.gauge_tolfactor / sqrt(iter), alg.tol_min, alg.tol_max)
     else # preserve legacy behavior
         tol_eigs = alg.tol_galerkin / 10
         tol_envs = Defaults.tol

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -7,52 +7,24 @@ https://arxiv.org/abs/1701.07035.
 # Fields
 - `tol_galerkin::Float64`: tolerance for convergence criterium
 - `maxiter::Int`: maximum amount of iterations
-- `orthmaxiter::Int`: maximum amount of gauging iterations
 - `finalize::F`: user-supplied function which is applied after each iteration, with
     signature `finalize(iter, ψ, H, envs) -> ψ, envs`
 - `verbose::Bool`: display progress information
-- `dynamical_tols::Bool`: whether to use dynamically adjusted tolerances
-- `tol_min::Float64`: minimum tolerance for subroutines
-- `tol_max::Float64`: maximum tolerance for subroutines
-- `eigs_tolfactor::Float64`: factor for dynamically setting the eigensolver tolerance  with
-    respect to the current galerkin error
-- `envs_tolfactor::Float64`: factor for dynamically setting the environment tolerance with
-    respect to the current galerkin error
-- `gauge_tolfactor::Float64`: factor for dynamically setting the gauging tolerance with
-    respect to the current galerkin error
+
+- `alg_gauge=Defaults.alg_gauge()`: algorithm for gauging
+- `alg_eigsolve=Defaults.alg_eigsolve()`: algorithm for eigensolvers
+- `alg_environments=Defaults.alg_environments()`: algorithm for updating environments
 """
 @kwdef struct VUMPS{F} <: Algorithm
     tol_galerkin::Float64 = Defaults.tol
     maxiter::Int = Defaults.maxiter
-    orthmaxiter::Int = Defaults.maxiter
     finalize::F = Defaults._finalize
     verbose::Bool = Defaults.verbose
-    dynamical_tols::Bool = Defaults.dynamical_tols
-    tol_min::Float64 = Defaults.tol_min
-    tol_max::Float64 = Defaults.tol_max
-    eigs_tolfactor::Float64 = Defaults.eigs_tolfactor
-    envs_tolfactor::Float64 = Defaults.envs_tolfactor
-    gauge_tolfactor::Float64 = Defaults.gauge_tolfactor
+
+    alg_gauge = Defaults.alg_gauge()
+    alg_eigsolve = Defaults.alg_eigsolve()
+    alg_environments = Defaults.alg_environments()
 end
-
-function updatetols(alg::VUMPS, iter, ϵ)
-    if alg.dynamical_tols
-        tol_eigs = clamp(ϵ * alg.eigs_tolfactor / sqrt(iter), alg.tol_min, alg.tol_max)
-        tol_envs = clamp(ϵ * alg.envs_tolfactor / sqrt(iter), alg.tol_min, alg.tol_max)
-        tol_gauge = clamp(ϵ * alg.gauge_tolfactor / sqrt(iter), alg.tol_min, alg.tol_max)
-    else # preserve legacy behavior
-        tol_eigs = alg.tol_galerkin / 10
-        tol_envs = Defaults.tol
-        tol_gauge = Defaults.tolgauge
-    end
-    return tol_eigs, tol_envs, tol_gauge
-end
-
-"
-    find_groundstate(ψ, H, alg, envs=environments(ψ, H))
-
-find the groundstate for `H` using algorithm `alg`
-"
 
 function find_groundstate(ψ::InfiniteMPS, H, alg::VUMPS, envs=environments(ψ, H))
     t₀ = Base.time_ns()
@@ -60,26 +32,28 @@ function find_groundstate(ψ::InfiniteMPS, H, alg::VUMPS, envs=environments(ψ, 
     temp_ACs = similar.(ψ.AC)
 
     for iter in 1:(alg.maxiter)
-        tol_eigs, tol_envs, tol_gauge = updatetols(alg, iter, ϵ)
         Δt = @elapsed begin
-            eigalg = Arnoldi(; tol=tol_eigs)
-
+            alg_eigsolve = updatetol(alg.alg_eigsolve, iter, ϵ)
             @static if Defaults.parallelize_sites
                 @sync begin
                     for loc in 1:length(ψ)
                         Threads.@spawn begin
-                            _vumps_localupdate!(temp_ACs[loc], loc, ψ, H, envs, eigalg)
+                            _vumps_localupdate!(temp_ACs[loc], loc, ψ, H, envs,
+                                                alg_eigsolve)
                         end
                     end
                 end
             else
                 for loc in 1:length(ψ)
-                    _vumps_localupdate!(temp_ACs[loc], loc, ψ, H, envs, eigalg)
+                    _vumps_localupdate!(temp_ACs[loc], loc, ψ, H, envs, alg_eigsolve)
                 end
             end
 
-            ψ = InfiniteMPS(temp_ACs, ψ.CR[end]; tol=tol_gauge, maxiter=alg.orthmaxiter)
-            recalculate!(envs, ψ; tol=tol_envs)
+            alg_gauge = updatetol(alg.alg_gauge, iter, ϵ)
+            ψ = InfiniteMPS(temp_ACs, ψ.CR[end]; alg_gauge.tol, alg_gauge.maxiter)
+
+            alg_environments = updatetol(alg.alg_environments, iter, ϵ)
+            recalculate!(envs, ψ; alg_environments.tol)
 
             ψ, envs = alg.finalize(iter, ψ, H, envs)::Tuple{typeof(ψ),typeof(envs)}
 

--- a/src/utility/defaults.jl
+++ b/src/utility/defaults.jl
@@ -14,7 +14,7 @@ const maxiter = 100
 const tolgauge = 1e-14
 const tol = 1e-12
 const verbose = true
-const dynamical_tols = true
+const dynamic_tols = true
 const tol_min = 1e-14
 const tol_max = 1e-5
 const eigs_tolfactor = 1e-5
@@ -30,24 +30,24 @@ const eigsolver = Arnoldi(; tol, maxiter, eager=true)
 # ------------------
 
 function alg_gauge(; tol=tolgauge, maxiter=maxiter,
-                   dynamical_tols=dynamical_tols, tol_min=tol_min, tol_max=tol_max,
+                   dynamic_tols=dynamic_tols, tol_min=tol_min, tol_max=tol_max,
                    tol_factor=gauge_tolfactor)
     alg = (; tol, maxiter)
-    return dynamical_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+    return dynamic_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
 end
 
 function alg_eigsolve(; tol=tol, maxiter=maxiter, eager=true,
-                      dynamical_tols=dynamical_tols, tol_min=tol_min, tol_max=tol_max,
+                      dynamic_tols=dynamic_tols, tol_min=tol_min, tol_max=tol_max,
                       tol_factor=eigs_tolfactor)
     alg = Arnoldi(; tol, maxiter, eager)
-    return dynamical_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+    return dynamic_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
 end
 
 function alg_environments(; tol=tol, maxiter=maxiter,
-                          dynamical_tols=dynamical_tols, tol_min=tol_min, tol_max=tol_max,
+                          dynamic_tols=dynamic_tols, tol_min=tol_min, tol_max=tol_max,
                           tol_factor=envs_tolfactor)
     alg = (; tol, maxiter)
-    return dynamical_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+    return dynamic_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
 end
 
 # Preferences

--- a/src/utility/defaults.jl
+++ b/src/utility/defaults.jl
@@ -7,6 +7,7 @@ module Defaults
 
 using Preferences
 import KrylovKit: GMRES, Arnoldi
+using ..MPSKit: ThrottledTol
 
 const eltype = ComplexF64
 const maxiter = 100
@@ -24,6 +25,30 @@ _finalize(iter, state, opp, envs) = (state, envs)
 
 const linearsolver = GMRES(; tol, maxiter)
 const eigsolver = Arnoldi(; tol, maxiter, eager=true)
+
+# Default algorithms
+# ------------------
+
+function alg_gauge(; tol=tolgauge, maxiter=maxiter,
+                   dynamical_tols=dynamical_tols, tol_min=tol_min, tol_max=tol_max,
+                   tol_factor=gauge_tolfactor)
+    alg = (; tol, maxiter)
+    return dynamical_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+end
+
+function alg_eigsolve(; tol=tol, maxiter=maxiter, eager=true,
+                      dynamical_tols=dynamical_tols, tol_min=tol_min, tol_max=tol_max,
+                      tol_factor=eigs_tolfactor)
+    alg = Arnoldi(; tol, maxiter, eager)
+    return dynamical_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+end
+
+function alg_environments(; tol=tol, maxiter=maxiter,
+                          dynamical_tols=dynamical_tols, tol_min=tol_min, tol_max=tol_max,
+                          tol_factor=envs_tolfactor)
+    alg = (; tol, maxiter)
+    return dynamical_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+end
 
 # Preferences
 # -----------

--- a/src/utility/defaults.jl
+++ b/src/utility/defaults.jl
@@ -7,7 +7,7 @@ module Defaults
 
 using Preferences
 import KrylovKit: GMRES, Arnoldi
-using ..MPSKit: ThrottledTol
+using ..MPSKit: DynamicTol
 
 const eltype = ComplexF64
 const maxiter = 100
@@ -33,21 +33,21 @@ function alg_gauge(; tol=tolgauge, maxiter=maxiter,
                    dynamic_tols=dynamic_tols, tol_min=tol_min, tol_max=tol_max,
                    tol_factor=gauge_tolfactor)
     alg = (; tol, maxiter)
-    return dynamic_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+    return dynamic_tols ? DynamicTol(alg, tol, tol_max, tol_factor) : alg
 end
 
 function alg_eigsolve(; tol=tol, maxiter=maxiter, eager=true,
                       dynamic_tols=dynamic_tols, tol_min=tol_min, tol_max=tol_max,
                       tol_factor=eigs_tolfactor)
     alg = Arnoldi(; tol, maxiter, eager)
-    return dynamic_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+    return dynamic_tols ? DynamicTol(alg, tol, tol_max, tol_factor) : alg
 end
 
 function alg_environments(; tol=tol, maxiter=maxiter,
                           dynamic_tols=dynamic_tols, tol_min=tol_min, tol_max=tol_max,
                           tol_factor=envs_tolfactor)
     alg = (; tol, maxiter)
-    return dynamic_tols ? ThrottledTol(alg, tol, tol_max, tol_factor) : alg
+    return dynamic_tols ? DynamicTol(alg, tol, tol_max, tol_factor) : alg
 end
 
 # Preferences

--- a/src/utility/dynamictols.jl
+++ b/src/utility/dynamictols.jl
@@ -29,7 +29,7 @@ struct DynamicTol{A} <: Algorithm
     tol_max::Float64
     tol_factor::Float64
     function DynamicTol(alg::A, tol_min::Real, tol_max::Real,
-                          tol_factor::Real) where {A}
+                        tol_factor::Real) where {A}
         0 <= tol_min <= tol_max ||
             throw(ArgumentError("tol_min must be between 0 and tol_max"))
         return new{A}(alg, tol_min, tol_max, tol_factor)

--- a/src/utility/dynamictols.jl
+++ b/src/utility/dynamictols.jl
@@ -1,9 +1,9 @@
-module ThrottledTols
+module DynamicTols
 
 import ..MPSKit: Algorithm
 using Accessors
 
-export updatetol, ThrottledTol
+export updatetol, DynamicTol
 
 @doc """
     updatetol(alg, iter, ϵ)
@@ -17,37 +17,37 @@ updatetol(alg, iter::Integer, ϵ::Real) = alg
 # ----------------------------------------
 
 """
-    ThrottledTol{A}(alg, tol_min, tol_max, tol_factor)
+    DynamicTol{A}(alg, tol_min, tol_max, tol_factor)
 
 Algorithm wrapper with dynamically adjusted tolerances.
 
 See also [`updatetol`](@ref).
 """
-struct ThrottledTol{A} <: Algorithm
+struct DynamicTol{A} <: Algorithm
     alg::A
     tol_min::Float64
     tol_max::Float64
     tol_factor::Float64
-    function ThrottledTol(alg::A, tol_min::Real, tol_max::Real,
+    function DynamicTol(alg::A, tol_min::Real, tol_max::Real,
                           tol_factor::Real) where {A}
         0 <= tol_min <= tol_max ||
             throw(ArgumentError("tol_min must be between 0 and tol_max"))
         return new{A}(alg, tol_min, tol_max, tol_factor)
     end
 end
-function ThrottledTol(alg; tol_min=1e-6, tol_max=1e-2, tol_factor=0.1)
-    return ThrottledTol(alg, tol_min, tol_max, tol_factor)
+function DynamicTol(alg; tol_min=1e-6, tol_max=1e-2, tol_factor=0.1)
+    return DynamicTol(alg, tol_min, tol_max, tol_factor)
 end
 
 """
-    updatetol(alg::ThrottledTol, iter, ϵ)
+    updatetol(alg::DynamicTol, iter, ϵ)
 
 Update the tolerance of the algorithm `alg` based on the current iteration `iter` and the current error `ϵ`,
 where the new tolerance is given by
     
     new_tol = clamp(ϵ * alg.tol_factor / sqrt(iter), alg.tol_min, alg.tol_max)
 """
-function updatetol(alg::ThrottledTol, iter::Integer, ϵ::Real)
+function updatetol(alg::DynamicTol, iter::Integer, ϵ::Real)
     new_tol = clamp(ϵ * alg.tol_factor / sqrt(iter), alg.tol_min, alg.tol_max)
     return _updatetol(alg.alg, new_tol)
 end

--- a/src/utility/throttledtol.jl
+++ b/src/utility/throttledtol.jl
@@ -1,3 +1,10 @@
+module ThrottledTols
+
+import ..MPSKit: Algorithm
+using Accessors
+
+export updatetol, ThrottledTol
+
 @doc """
     updatetol(alg, iter, ϵ)
 
@@ -48,4 +55,6 @@ end
 # default implementation with Accessors.jl, but can be hooked into
 function _updatetol(alg, tol::Real)
     return @set alg.tol = tol
+end
+
 end

--- a/src/utility/throttledtol.jl
+++ b/src/utility/throttledtol.jl
@@ -1,0 +1,51 @@
+@doc """
+    updatetol(alg, iter, ϵ)
+
+Update the tolerance of the algorithm `alg` based on the current iteration `iter` and the current error `ϵ`.
+""" updatetol
+
+updatetol(alg, iter::Integer, ϵ::Real) = alg
+
+# Wrapper for dynamic tolerance adjustment
+# ----------------------------------------
+
+"""
+    ThrottledTol{A}(alg, tol_min, tol_max, tol_factor)
+
+Algorithm wrapper with dynamically adjusted tolerances.
+
+See also [`updatetol`](@ref).
+"""
+struct ThrottledTol{A} <: Algorithm
+    alg::A
+    tol_min::Float64
+    tol_max::Float64
+    tol_factor::Float64
+    function ThrottledTol(alg::A, tol_min::Real, tol_max::Real,
+                          tol_factor::Real) where {A}
+        0 <= tol_min <= tol_max ||
+            throw(ArgumentError("tol_min must be between 0 and tol_max"))
+        return new{A}(alg, tol_min, tol_max, tol_factor)
+    end
+end
+function ThrottledTol(alg; tol_min=1e-6, tol_max=1e-2, tol_factor=0.1)
+    return ThrottledTol(alg, tol_min, tol_max, tol_factor)
+end
+
+"""
+    updatetol(alg::ThrottledTol, iter, ϵ)
+
+Update the tolerance of the algorithm `alg` based on the current iteration `iter` and the current error `ϵ`,
+where the new tolerance is given by
+    
+    new_tol = clamp(ϵ * alg.tol_factor / sqrt(iter), alg.tol_min, alg.tol_max)
+"""
+function updatetol(alg::ThrottledTol, iter::Integer, ϵ::Real)
+    new_tol = clamp(ϵ * alg.tol_factor / sqrt(iter), alg.tol_min, alg.tol_max)
+    return _updatetol(alg.alg, new_tol)
+end
+
+# default implementation with Accessors.jl, but can be hooked into
+function _updatetol(alg, tol::Real)
+    return @set alg.tol = tol
+end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -138,10 +138,3 @@ end
 @static if !isdefined(Base, :allequal)
     allequal(itr) = isempty(itr) ? true : all(isequal(first(itr)), itr)
 end
-
-function between(x1, x, x2)
-    @assert x1 <= x2 "x1 should be smaller than  or equal to x2"
-    x < x1 && return x1
-    x > x2 && return x2
-    return x
-end


### PR DESCRIPTION
This cleans up some of the keyword arguments of VUMPS that are not necessary when you do not want to use dynamic tolerances. Additionally, it removes `between`, as this is a copy of `Base.clamp`, and streamlines the creation of default subalgorithms. Finally, `dynamical` is replaced with `dynamic`.

Note that this is quite breaking, as many of the original keywords for VUMPS no longer exist. I think this is warranted, and want to include most of these breaking changes in the transition to v0.11.0. Do you think explicit deprecation warnings are necessary/warranted, or can we just make the changes breaking with the argument v0.x can change the interface?