### PR TITLE
Refactor tests into modules

### DIFF
--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -13,7 +13,7 @@ using TensorKit: ℙ
 
 @testset "find_groundstate" verbose = true begin
     tol = 1e-8
-    verbosity = 2
+    verbosity = 0
     infinite_algs = [VUMPS(; tol_galerkin=tol, verbose=verbosity > 0),
                      IDMRG1(; tol_galerkin=tol, verbose=verbosity > 0),
                      IDMRG2(; trscheme=truncdim(12), tol_galerkin=tol,

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -23,11 +23,12 @@ using TensorKit: ℙ
                      GradientGrassmann(; tol=tol, verbosity=verbosity)]
     
     g = 4.0
+    D = 6
     H1 = force_planar(transverse_field_ising(; g))
 
     @testset "Infinite $i" for (i, alg) in enumerate(infinite_algs)
         L = alg isa IDMRG2 ? 2 : 1
-        ψ₀ = repeat(InfiniteMPS([ℙ^2], [ℙ^16]), L)
+        ψ₀ = repeat(InfiniteMPS([ℙ^2], [ℙ^D]), L)
         H = repeat(H1, L)
 
         v₀ = variance(ψ₀, H)
@@ -42,7 +43,7 @@ using TensorKit: ℙ
 
     @testset "LazySum Infinite $i" for (i, alg) in enumerate(infinite_algs)
         L = alg isa IDMRG2 ? 2 : 1
-        ψ₀ = repeat(InfiniteMPS([ℙ^2], [ℙ^16]), L)
+        ψ₀ = repeat(InfiniteMPS([ℙ^2], [ℙ^D]), L)
         Hlazy = repeat(Hlazy1, L)
 
         v₀ = variance(ψ₀, Hlazy)
@@ -59,13 +60,13 @@ using TensorKit: ℙ
     end
 
     finite_algs = [DMRG(; verbose=verbosity > 0),
-                   DMRG2(; verbose=verbosity > 0, trscheme=truncdim(10)),
+                   DMRG2(; verbose=verbosity > 0, trscheme=truncdim(D)),
                    GradientGrassmann(; tol=tol, verbosity=verbosity)]
 
     H = force_planar(transverse_field_ising(; g))
 
     @testset "Finite $i" for (i, alg) in enumerate(finite_algs)
-        ψ₀ = FiniteMPS(rand, ComplexF64, 10, ℙ^2, ℙ^10)
+        ψ₀ = FiniteMPS(rand, ComplexF64, 10, ℙ^2, ℙ^D)
 
         v₀ = variance(ψ₀, H)
         ψ, envs, δ = find_groundstate(ψ₀, H, alg)
@@ -78,7 +79,7 @@ using TensorKit: ℙ
     Hlazy = LazySum([H, H, H])
 
     @testset "LazySum Finite $i" for (i, alg) in enumerate(finite_algs)
-        ψ₀ = FiniteMPS(rand, ComplexF64, 10, ℙ^2, ℙ^10)
+        ψ₀ = FiniteMPS(rand, ComplexF64, 10, ℙ^2, ℙ^D)
 
         v₀ = variance(ψ₀, Hlazy)
         ψ, envs, δ = find_groundstate(ψ₀, Hlazy, alg)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -21,7 +21,7 @@ using TensorKit: ℙ
                      GradientGrassmann(; tol=tol, verbosity=verbosity),
                      VUMPS(; tol_galerkin=100 * tol, verbose=verbosity > 0) &
                      GradientGrassmann(; tol=tol, verbosity=verbosity)]
-    
+
     g = 4.0
     D = 6
     H1 = force_planar(transverse_field_ising(; g))

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -13,7 +13,7 @@ using TensorKit: ℙ
 
 @testset "find_groundstate" verbose = true begin
     tol = 1e-8
-    verbosity = 0
+    verbosity = 2
     infinite_algs = [VUMPS(; tol_galerkin=tol, verbose=verbosity > 0),
                      IDMRG1(; tol_galerkin=tol, verbose=verbosity > 0),
                      IDMRG2(; trscheme=truncdim(12), tol_galerkin=tol,
@@ -61,7 +61,7 @@ using TensorKit: ℙ
 
     finite_algs = [DMRG(; verbose=verbosity > 0),
                    DMRG2(; verbose=verbosity > 0, trscheme=truncdim(D)),
-                   GradientGrassmann(; tol=tol, verbosity=verbosity)]
+                   GradientGrassmann(; tol, verbosity, maxiter=300)]
 
     H = force_planar(transverse_field_ising(; g))
 
@@ -72,11 +72,11 @@ using TensorKit: ℙ
         ψ, envs, δ = find_groundstate(ψ₀, H, alg)
         v = variance(ψ, H, envs)
 
-        @test sum(δ) < 100 * tol
+        @test sum(δ) < 1e-3
         @test v₀ > v && v < 1e-2 # energy variance should be low
     end
 
-    Hlazy = LazySum([H, H, H])
+    Hlazy = LazySum([3 * H, H, 5.557 * H])
 
     @testset "LazySum Finite $i" for (i, alg) in enumerate(finite_algs)
         ψ₀ = FiniteMPS(rand, ComplexF64, 10, ℙ^2, ℙ^D)
@@ -85,7 +85,7 @@ using TensorKit: ℙ
         ψ, envs, δ = find_groundstate(ψ₀, Hlazy, alg)
         v = variance(ψ, Hlazy)
 
-        @test sum(δ) < 100 * tol
+        @test sum(δ) < 1e-3
         @test v₀ > v && v < 1e-2 # energy variance should be low
 
         ψ_nolazy, envs_nolazy, _ = find_groundstate(ψ₀, sum(Hlazy), alg)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -3,8 +3,13 @@ println("
 |   Algorithms   |
 ------------------
 ")
+module TestAlgorithms
 
-include("setup.jl")
+using ..TestSetup
+using Test, TestExtras
+using MPSKit
+using TensorKit
+using TensorKit: ℙ
 
 @testset "find_groundstate" verbose = true begin
     tol = 1e-8
@@ -16,12 +21,13 @@ include("setup.jl")
                      GradientGrassmann(; tol=tol, verbosity=verbosity),
                      VUMPS(; tol_galerkin=100 * tol, verbose=verbosity > 0) &
                      GradientGrassmann(; tol=tol, verbosity=verbosity)]
-
-    H1 = force_planar(transverse_field_ising(; g=1.1))
+    
+    g = 4.0
+    H1 = force_planar(transverse_field_ising(; g))
 
     @testset "Infinite $i" for (i, alg) in enumerate(infinite_algs)
         L = alg isa IDMRG2 ? 2 : 1
-        ψ₀ = repeat(InfiniteMPS([ℙ^2], [ℙ^15]), L)
+        ψ₀ = repeat(InfiniteMPS([ℙ^2], [ℙ^16]), L)
         H = repeat(H1, L)
 
         v₀ = variance(ψ₀, H)
@@ -56,7 +62,7 @@ include("setup.jl")
                    DMRG2(; verbose=verbosity > 0, trscheme=truncdim(10)),
                    GradientGrassmann(; tol=tol, verbosity=verbosity)]
 
-    H = force_planar(transverse_field_ising(; g=1.1))
+    H = force_planar(transverse_field_ising(; g))
 
     @testset "Finite $i" for (i, alg) in enumerate(finite_algs)
         ψ₀ = FiniteMPS(rand, ComplexF64, 10, ℙ^2, ℙ^10)
@@ -525,4 +531,6 @@ end
 
     energies, values = exact_diagonalization(th; which=:SR)
     @test energies[1] ≈ sum(expectation_value(gs, th)) atol = 1e-5
+end
+
 end

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -3,8 +3,15 @@ println("
 |   Operators   |
 -----------------
 ")
+module TestOperators
 
-include("setup.jl")
+using ..TestSetup
+using Test, TestExtras
+using MPSKit
+using MPSKit: _transpose_front, _transpose_tail
+using TensorKit
+using TensorKit: ℙ
+using VectorInterface: One
 
 pspaces = (ℙ^4, Rep[U₁](0 => 2), Rep[SU₂](1 => 1))
 vspaces = (ℙ^10, Rep[U₁]((0 => 20)), Rep[SU₂](1 // 2 => 10, 3 // 2 => 5, 5 // 2 => 1))
@@ -210,7 +217,7 @@ vspaces = (ℙ^10, Rep[U₁]((0 => 20)), Rep[SU₂](1 => 10, 3 => 5, 5 => 1))
         end
         @test summedhct(ψ.AC[1], 0.0) ≈ sum2
 
-        v = MPSKit._transpose_front(ψ.AC[1]) * MPSKit._transpose_tail(ψ.AR[2])
+        v = _transpose_front(ψ.AC[1]) * _transpose_tail(ψ.AR[2])
         summedhct = MPSKit.∂∂AC2(1, ψ, summedH, summedEnvs)
         sum3 = sum(zip(Hs, Envs)) do (H, env)
             return MPSKit.∂∂AC2(1, ψ, H, env)(v)
@@ -260,7 +267,7 @@ vspaces = (ℙ^10, Rep[U₁]((0 => 20)), Rep[SU₂](1 => 10, 3 => 5, 5 => 1))
         end
         @test summedhct(ψ.AC[1], t) ≈ sum2
 
-        v = MPSKit._transpose_front(ψ.AC[1]) * MPSKit._transpose_tail(ψ.AR[2])
+        v = _transpose_front(ψ.AC[1]) * _transpose_tail(ψ.AR[2])
         summedhct = MPSKit.∂∂AC2(1, ψ, summedH, summedEnvs)
         sum3 = sum(zip(fs, Hs, Envs)) do (f, H, env)
             if f isa Function
@@ -270,4 +277,6 @@ vspaces = (ℙ^10, Rep[U₁]((0 => 20)), Rep[SU₂](1 => 10, 3 => 5, 5 => 1))
         end
         @test summedhct(v, t) ≈ sum3
     end
+end
+
 end

--- a/test/other.jl
+++ b/test/other.jl
@@ -3,8 +3,13 @@ println("
 |   Miscellaneous   |
 ---------------------
 ")
+module TestMiscellaneous
 
-include("setup.jl")
+using ..TestSetup
+using Test, TestExtras
+using MPSKit
+using TensorKit
+using TensorKit: ℙ
 using Plots
 
 @testset "plot tests" begin
@@ -43,4 +48,6 @@ end
         @test ψ2 isa InfiniteMPS
         @test norm(ψ2) ≈ 1
     end
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
-using Pkg, Test
-
+using Test
 const GROUP = uppercase(get(ENV, "GROUP", "ALL"))
+
+include("setup.jl")
 
 @time begin
     if GROUP == "ALL" || GROUP == "STATES"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,23 +5,15 @@ include("setup.jl")
 
 @time begin
     if GROUP == "ALL" || GROUP == "STATES"
-        @time @testset "States" verbose = true begin
-            include("states.jl")
-        end
+        @time include("states.jl")
     end
     if GROUP == "ALL" || GROUP == "OPERATORS"
-        @time @testset "Operators" verbose = true begin
-            include("operators.jl")
-        end
+        @time include("operators.jl")
     end
     if GROUP == "ALL" || GROUP == "ALGORITHMS"
-        @time @testset "Algorithms" verbose = true begin
-            include("algorithms.jl")
-        end
+        @time include("algorithms.jl")
     end
     if GROUP == "ALL" || GROUP == "OTHER"
-        @time @testset "Other" verbose = true begin
-            include("other.jl")
-        end
+        @time include("other.jl")
     end
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,12 +1,17 @@
 # Planar stuff
 # ----------------------------
+module TestSetup
 
-using Test, TestExtras
+# imports
 using MPSKit
-using MPSKit: _transpose_tail, _transpose_front
 using TensorKit
 using TensorKit: PlanarTrivial, ℙ
-using VectorInterface: One
+using LinearAlgebra: Diagonal
+
+# exports
+export force_planar
+export transverse_field_ising, heisenberg_XXX, bilinear_biquadratic_model
+export classical_ising, finite_classical_ising, sixvertex
 
 # using TensorOperations
 
@@ -29,7 +34,6 @@ force_planar(mpo::DenseMPO) = DenseMPO(force_planar.(mpo.opp))
 
 # Toy models
 # ----------------------------
-using LinearAlgebra: Diagonal
 
 function transverse_field_ising(; g=1.0)
     X = TensorMap(ComplexF64[0 1; 1 0], ℂ^2 ← ℂ^2)
@@ -123,4 +127,6 @@ function sixvertex(; a=1.0, b=1.0, c=1.0)
                    0 b c 0
                    0 0 0 a]
     return DenseMPO(permute(TensorMap(d, ℂ^2 ⊗ ℂ^2, ℂ^2 ⊗ ℂ^2), ((1, 2), (4, 3))))
+end
+
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -40,7 +40,7 @@ function transverse_field_ising(; g=1.0)
     Z = TensorMap(ComplexF64[1 0; 0 -1], ℂ^2 ← ℂ^2)
     E = TensorMap(ComplexF64[1 0; 0 1], ℂ^2 ← ℂ^2)
     H = Z ⊗ Z + (g / 2) * (X ⊗ E + E ⊗ X)
-    return MPOHamiltonian(H)
+    return MPOHamiltonian(-H)
 end
 
 function heisenberg_XXX(::Type{SU2Irrep}; spin=1)

--- a/test/states.jl
+++ b/test/states.jl
@@ -3,8 +3,14 @@ println("
 |   States   |
 --------------
 ")
+module TestStates
 
-include("setup.jl")
+using ..TestSetup
+using Test, TestExtras
+using MPSKit
+using MPSKit: _transpose_front, _transpose_tail
+using TensorKit
+using TensorKit: ℙ
 
 @testset "FiniteMPS ($(sectortype(D)), $elt)" for (D, d, elt) in [(ℙ^10, ℙ^2, ComplexF64),
                                                                   (Rep[SU₂](1 => 1, 0 => 3),
@@ -18,8 +24,7 @@ include("setup.jl")
 
     for i in 1:length(ψ)
         @test ψ.AC[i] ≈ ψ.AL[i] * ψ.CR[i]
-        @test ψ.AC[i] ≈
-              MPSKit._transpose_front(ψ.CR[i - 1] * MPSKit._transpose_tail(ψ.AR[i]))
+        @test ψ.AC[i] ≈ _transpose_front(ψ.CR[i - 1] * _transpose_tail(ψ.AR[i]))
     end
 
     @test elt == scalartype(ψ)
@@ -111,8 +116,8 @@ end
 
     for i in 1:length(window)
         @test window.AC[i] ≈ window.AL[i] * window.CR[i]
-        @test window.AC[i] ≈ MPSKit._transpose_front(window.CR[i - 1] *
-                                                     MPSKit._transpose_tail(window.AR[i]))
+        @test window.AC[i] ≈
+              _transpose_front(window.CR[i - 1] * _transpose_tail(window.AR[i]))
     end
 
     @test norm(window) ≈ 1
@@ -133,8 +138,8 @@ end
     @test v2 < v1
     @test real(e2[2]) ≤ real(e1[2])
 
-    (window, envs) = timestep(window, ham, 0.1, 0.0, TDVP2(), envs)
-    (window, envs) = timestep(window, ham, 0.1, 0.0, TDVP(), envs)
+    window, envs = timestep(window, ham, 0.1, 0.0, TDVP2(), envs)
+    window, envs = timestep(window, ham, 0.1, 0.0, TDVP(), envs)
 
     e3 = expectation_value(window, ham)
 
@@ -189,4 +194,6 @@ end
                   convert(MPSKit.LeftGaugedQP, convert(MPSKit.RightGaugedQP, ϕ₁))) ≈
               dot(ϕ₁, ϕ₁) atol = 1e-10
     end
+end
+
 end


### PR DESCRIPTION
This removes the warning messages that the tests were throwing about multiple inclusions. Fixes #115 .

Additionally, changes some of the tolerances and bonddimensions around in the test algorithms for groundstate search to make them a bit more stable