### PR TITLE
VOMPS

### DIFF
--- a/docs/src/lib/lib.md
+++ b/docs/src/lib/lib.md
@@ -72,6 +72,7 @@ WII
 ### [Leading boundary algorithms](@id lib_bound_alg)
 ```@docs
 VUMPS
+VOMPS
 GradientGrassmann
 ```
 

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -36,7 +36,7 @@ export leftenv, rightenv
 
 # algos
 export find_groundstate!, find_groundstate, leading_boundary
-export VUMPS, DMRG, DMRG2, IDMRG1, IDMRG2, GradientGrassmann
+export VUMPS, VOMPS, DMRG, DMRG2, IDMRG1, IDMRG2, GradientGrassmann
 export excitations, FiniteExcited, QuasiparticleAnsatz
 export marek_gap, correlation_length, correlator
 export time_evolve, timestep!, timestep
@@ -141,6 +141,7 @@ include("algorithms/excitation/dmrgexcitation.jl")
 include("algorithms/excitation/exci_transfer_system.jl")
 
 include("algorithms/statmech/vumps.jl")
+include("algorithms/statmech/vomps.jl")
 include("algorithms/statmech/gradient_grassmann.jl")
 
 include("algorithms/fidelity_susceptibility.jl")

--- a/src/algorithms/approximate/approximate.jl
+++ b/src/algorithms/approximate/approximate.jl
@@ -22,6 +22,6 @@ of an MPS `ψ₀`.
 
 - `IDMRG1`: Variant of `DMRG` for maximizing fidelity density in the thermodynamic limit.
 - `IDMRG2`: Variant of `DMRG2` for maximizing fidelity density in the thermodynamic limit.
-- `VUMPS`: Tangent space method for truncating uniform MPS. See [SciPost:4.1.004](https://scipost.org/SciPostPhysCore.4.1.004). Also known as "VOMPS".
+- `VOMPS`: Tangent space method for truncating uniform MPS.
 """
 approximate, approximate!

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -10,7 +10,7 @@ function approximate(ψ::InfiniteMPS,
 end
 
 Base.@deprecate(approximate(ψ::MPSMultiline, toapprox::Tuple{<:MPOMultiline,<:MPSMultiline},
-                            alg::VUMPS, envs...),
+                            alg::VUMPS, envs...; kwargs...),
                 approximate(ψ, toapprox,
                             VOMPS(; alg.tol, alg.maxiter, alg.finalize,
                                   alg.verbosity, alg.alg_gauge, alg.alg_environments),

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -1,3 +1,29 @@
+"""
+    VOMPS{F} <: Algorithm
+    
+Power method algorithm for infinite MPS.
+[SciPost:4.1.004](https://scipost.org/SciPostPhysCore.4.1.004)
+    
+## Fields
+- `tol::Float64`: tolerance for convergence criterium
+- `maxiter::Int`: maximum amount of iterations
+- `finalize::F`: user-supplied function which is applied after each iteration, with
+    signature `finalize(iter, ψ, toapprox, envs) -> ψ, envs`
+- `verbosity::Int`: display progress information
+
+- `alg_gauge=Defaults.alg_gauge()`: algorithm for gauging
+- `alg_environments=Defaults.alg_environments()`: algorithm for updating environments
+"""
+@kwdef struct VOMPS{F} <: Algorithm
+    tol::Float64 = Defaults.tol
+    maxiter::Int = Defaults.maxiter
+    finalize::F = Defaults._finalize
+    verbosity::Int = Defaults.verbosity
+
+    alg_gauge = Defaults.alg_gauge()
+    alg_environments = Defaults.alg_environments()
+end
+
 function approximate(ψ::InfiniteMPS,
                      toapprox::Tuple{<:Union{SparseMPO,DenseMPO},<:InfiniteMPS}, algorithm,
                      envs=environments(ψ, toapprox))
@@ -8,8 +34,15 @@ function approximate(ψ::InfiniteMPS,
     ψ = convert(InfiniteMPS, multi)
     return ψ, envs
 end
+
+Base.@deprecate(approximate(ψ, toapprox, alg::VUMPS, envs...),
+                approximate(ψ, toapprox,
+                            VOMPS(; alg.tol, alg.maxiter, alg.finalize,
+                                  alg.verbosity, alg.alg_gauge, alg.alg_environments),
+                            envs...; kwargs...))
+
 function approximate(ψ::MPSMultiline, toapprox::Tuple{<:MPOMultiline,<:MPSMultiline},
-                     alg::VUMPS, envs=environments(ψ, toapprox))
+                     alg::VOMPS, envs=environments(ψ, toapprox))
     ϵ::Float64 = calc_galerkin(ψ, envs)
     temp_ACs = similar.(ψ.AC)
     log = IterLog("VOMPS")

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -1,29 +1,3 @@
-"""
-    VOMPS{F} <: Algorithm
-    
-Power method algorithm for infinite MPS.
-[SciPost:4.1.004](https://scipost.org/SciPostPhysCore.4.1.004)
-    
-## Fields
-- `tol::Float64`: tolerance for convergence criterium
-- `maxiter::Int`: maximum amount of iterations
-- `finalize::F`: user-supplied function which is applied after each iteration, with
-    signature `finalize(iter, ψ, toapprox, envs) -> ψ, envs`
-- `verbosity::Int`: display progress information
-
-- `alg_gauge=Defaults.alg_gauge()`: algorithm for gauging
-- `alg_environments=Defaults.alg_environments()`: algorithm for updating environments
-"""
-@kwdef struct VOMPS{F} <: Algorithm
-    tol::Float64 = Defaults.tol
-    maxiter::Int = Defaults.maxiter
-    finalize::F = Defaults._finalize
-    verbosity::Int = Defaults.verbosity
-
-    alg_gauge = Defaults.alg_gauge()
-    alg_environments = Defaults.alg_environments()
-end
-
 function approximate(ψ::InfiniteMPS,
                      toapprox::Tuple{<:Union{SparseMPO,DenseMPO},<:InfiniteMPS}, algorithm,
                      envs=environments(ψ, toapprox))

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -9,7 +9,8 @@ function approximate(ψ::InfiniteMPS,
     return ψ, envs
 end
 
-Base.@deprecate(approximate(ψ, toapprox, alg::VUMPS, envs...),
+Base.@deprecate(approximate(ψ::MPSMultiline, toapprox::Tuple{<:MPOMultiline,<:MPSMultiline},
+                            alg::VUMPS, envs...),
                 approximate(ψ, toapprox,
                             VOMPS(; alg.tol, alg.maxiter, alg.finalize,
                                   alg.verbosity, alg.alg_gauge, alg.alg_environments),

--- a/src/algorithms/statmech/vomps.jl
+++ b/src/algorithms/statmech/vomps.jl
@@ -1,0 +1,92 @@
+"""
+    VOMPS{F} <: Algorithm
+    
+Power method algorithm for infinite MPS.
+[SciPost:4.1.004](https://scipost.org/SciPostPhysCore.4.1.004)
+    
+## Fields
+- `tol::Float64`: tolerance for convergence criterium
+- `maxiter::Int`: maximum amount of iterations
+- `finalize::F`: user-supplied function which is applied after each iteration, with
+    signature `finalize(iter, ψ, toapprox, envs) -> ψ, envs`
+- `verbosity::Int`: display progress information
+
+- `alg_gauge=Defaults.alg_gauge()`: algorithm for gauging
+- `alg_environments=Defaults.alg_environments()`: algorithm for updating environments
+"""
+@kwdef struct VOMPS{F} <: Algorithm
+    tol::Float64 = Defaults.tol
+    maxiter::Int = Defaults.maxiter
+    finalize::F = Defaults._finalize
+    verbosity::Int = Defaults.verbosity
+
+    alg_gauge = Defaults.alg_gauge()
+    alg_environments = Defaults.alg_environments()
+end
+
+function leading_boundary(ψ::MPSMultiline, O::MPOMultiline, alg::VOMPS,
+                          envs=environments(ψ, O))
+    ϵ::Float64 = calc_galerkin(ψ, envs)
+    temp_ACs = similar.(ψ.AC)
+    temp_Cs = similar.(ψ.CR)
+    log = IterLog("VOMPS")
+
+    LoggingExtras.withlevel(; alg.verbosity) do
+        @infov 2 loginit!(log, ϵ, sum(expectation_value(ψ, O, envs)))
+        for iter in 1:(alg.maxiter)
+            @static if Defaults.parallelize_sites
+                @sync for col in 1:size(ψ, 2)
+                    Threads.@spawn begin
+                        H_AC = ∂∂AC(col, ψ, O, envs)
+                        ac = RecursiveVec(ψ.AC[:, col])
+                        temp_ACs[:, col] .= H_AC(ac)
+                    end
+
+                    Threads.@spawn begin
+                        H_C = ∂∂C(col, ψ, O, envs)
+                        c = RecursiveVec(ψ.CR[:, col])
+                        temp_Cs[:, col] .= H_C(c)
+                    end
+                end
+            else
+                for col in 1:size(ψ, 2)
+                    H_AC = ∂∂AC(col, ψ, O, envs)
+                    ac = RecursiveVec(ψ.AC[:, col])
+                    temp_ACs[:, col] .= H_AC(ac)
+
+                    H_C = ∂∂C(col, ψ, O, envs)
+                    c = RecursiveVec(ψ.CR[:, col])
+                    temp_Cs[:, col] .= H_C(c)
+                end
+            end
+
+            for row in 1:size(ψ, 1), col in 1:size(ψ, 2)
+                QAc, _ = leftorth!(temp_ACs[row, col]; alg=TensorKit.QRpos())
+                Qc, _ = leftorth!(temp_Cs[row, col]; alg=TensorKit.QRpos())
+                temp_ACs[row, col] = QAc * adjoint(Qc)
+            end
+
+            alg_gauge = updatetol(alg.alg_gauge, iter, ϵ)
+            ψ = MPSMultiline(temp_ACs, ψ.CR[:, end]; alg_gauge.tol, alg_gauge.maxiter)
+
+            alg_environments = updatetol(alg.alg_environments, iter, ϵ)
+            recalculate!(envs, ψ; alg_environments.tol)
+
+            ψ, envs = alg.finalize(iter, ψ, O, envs)::Tuple{typeof(ψ),typeof(envs)}
+
+            ϵ = calc_galerkin(ψ, envs)
+
+            if ϵ <= alg.tol
+                @infov 2 logfinish!(log, iter, ϵ, sum(expectation_value(ψ, O, envs)))
+                break
+            end
+            if iter == alg.maxiter
+                @warnv 1 logcancel!(log, iter, ϵ, sum(expectation_value(ψ, O, envs)))
+            else
+                @infov 3 logiter!(log, iter, ϵ, sum(expectation_value(ψ, O, envs)))
+            end
+        end
+    end
+
+    return ψ, envs, ϵ
+end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -183,7 +183,9 @@ end
 end
 
 @testset "leading_boundary" verbose = true begin
-    algs = [VUMPS(; tol=1e-5, verbosity=0), GradientGrassmann(; verbosity=0)]
+    tol = 1e-5
+    verbosity = 0
+    algs = [VUMPS(; tol, verbosity), VOMPS(; tol, verbosity), GradientGrassmann(; verbosity)]
     mpo = force_planar(classical_ising())
 
     ψ₀ = InfiniteMPS([ℙ^2], [ℙ^10])

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -185,7 +185,8 @@ end
 @testset "leading_boundary" verbose = true begin
     tol = 1e-5
     verbosity = 0
-    algs = [VUMPS(; tol, verbosity), VOMPS(; tol, verbosity), GradientGrassmann(; verbosity)]
+    algs = [VUMPS(; tol, verbosity), VOMPS(; tol, verbosity),
+            GradientGrassmann(; verbosity)]
     mpo = force_planar(classical_ising())
 
     ψ₀ = InfiniteMPS([ℙ^2], [ℙ^10])

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -441,6 +441,7 @@ end
 end
 
 @testset "approximate" verbose = true begin
+    verbosity = 0
     @testset "mpo * infinite ≈ infinite" begin
         st = InfiniteMPS([ℙ^2, ℙ^2], [ℙ^10, ℙ^10])
         th = force_planar(repeat(transverse_field_ising(; g=4), 2))
@@ -451,10 +452,10 @@ end
         W1 = convert(DenseMPO, sW1)
         W2 = convert(DenseMPO, sW2)
 
-        st1, _ = approximate(st, (sW1, st), VUMPS(; verbosity=0))
-        st2, _ = approximate(st, (W2, st), VUMPS(; verbosity=0))
-        st3, _ = approximate(st, (W1, st), IDMRG1(; verbosity=0))
-        st4, _ = approximate(st, (sW2, st), IDMRG2(; trscheme=truncdim(20), verbosity=0))
+        st1, _ = approximate(st, (sW1, st), VOMPS(; verbosity))
+        st2, _ = approximate(st, (W2, st), VOMPS(; verbosity))
+        st3, _ = approximate(st, (W1, st), IDMRG1(; verbosity))
+        st4, _ = approximate(st, (sW2, st), IDMRG2(; trscheme=truncdim(20), verbosity))
         st5, _ = timestep(st, th, 0.0, dt, TDVP())
         st6 = changebonds(W1 * st, SvdCut(; trscheme=truncdim(10)))
 
@@ -467,7 +468,7 @@ end
         @test dim(space(nW1.opp[1, 1], 1)) == 1
     end
 
-    finite_algs = [DMRG(; verbosity=0), DMRG2(; verbosity=0, trscheme=truncdim(10))]
+    finite_algs = [DMRG(; verbosity), DMRG2(; verbosity, trscheme=truncdim(10))]
     @testset "finitemps1 ≈ finitemps2" for alg in finite_algs
         a = FiniteMPS(10, ℂ^2, ℂ^10)
         b = FiniteMPS(10, ℂ^2, ℂ^20)


### PR DESCRIPTION
This PR adds `VOMPS` as a separate flavour for computing `leading_boundary`. This effectively is equivalent to a power method.