### PR TITLE
Refactor infinite gaugefixing

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -70,6 +70,7 @@ include("utility/defaults.jl")
 using .Defaults: VERBOSE_NONE, VERBOSE_WARN, VERBOSE_CONV, VERBOSE_ITER, VERBOSE_ALL
 include("utility/logging.jl")
 using .IterativeLoggers
+include("utility/iterativesolvers.jl")
 
 include("utility/periodicarray.jl")
 include("utility/multiline.jl")

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -27,12 +27,13 @@ function approximate(ψ::MPSMultiline, toapprox::Tuple{<:MPOMultiline,<:MPSMulti
         for iter in 1:(alg.maxiter)
             @static if Defaults.parallelize_sites
                 @sync for col in 1:size(ψ, 2)
-                    Threads.@spawn _vomps_localupdate!(temp_ACs[:, col], col, ψ, toapprox,
-                                                       envs)
+                    Threads.@spawn begin
+                        temp_ACs[:, col] = _vomps_localupdate(col, ψ, toapprox, envs)
+                    end
                 end
             else
                 for col in 1:size(ψ, 2)
-                    _vomps_localupdate!(temp_ACs[:, col], col, ψ, toapprox, envs)
+                    tem_ACs[:, col] = _vomps_localupdate(col, ψ, toapprox, envs)
                 end
             end
 
@@ -61,24 +62,19 @@ function approximate(ψ::MPSMultiline, toapprox::Tuple{<:MPOMultiline,<:MPSMulti
     return ψ, envs, ϵ
 end
 
-function _vomps_localupdate!(AC′, loc, ψ, (O, ψ₀), envs, factalg=QRpos())
-    local Q_AC, Q_C
+function _vomps_localupdate(loc, ψ, (O, ψ₀), envs, factalg=QRpos())
     @static if Defaults.parallelize_sites
         @sync begin
             Threads.@spawn begin
                 tmp_AC = circshift([ac_proj(row, loc, ψ, envs) for row in 1:size(ψ, 1)], 1)
-                Q_AC = first.(leftorth!.(tmp_AC; alg=factalg))
             end
             Threads.@spawn begin
                 tmp_C = circshift([c_proj(row, loc, ψ, envs) for row in 1:size(ψ, 1)], 1)
-                Q_C = first.(leftorth!.(tmp_C; alg=factalg))
             end
         end
     else
         tmp_AC = circshift([ac_proj(row, loc, ψ, envs) for row in 1:size(ψ, 1)], 1)
-        Q_AC = first.(leftorth!.(tmp_AC; alg=factalg))
         tmp_C = circshift([c_proj(row, loc, ψ, envs) for row in 1:size(ψ, 1)], 1)
-        Q_C = first.(leftorth!.(tmp_C; alg=factalg))
     end
-    return mul!.(AC′, Q_AC, adjoint.(Q_C))
+    return regauge!.(tmp_AC, tmp_C; alg=factalg)
 end

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -33,7 +33,7 @@ function approximate(ψ::MPSMultiline, toapprox::Tuple{<:MPOMultiline,<:MPSMulti
                 end
             else
                 for col in 1:size(ψ, 2)
-                    tem_ACs[:, col] = _vomps_localupdate(col, ψ, toapprox, envs)
+                    temp_ACs[:, col] = _vomps_localupdate(col, ψ, toapprox, envs)
                 end
             end
 

--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -22,6 +22,7 @@ function changebonds!(ψ::AbstractFiniteMPS, alg::SvdCut)
     return normalize!(ψ)
 end
 
+# TODO: this assumes the MPO is infinite, and does weird things for finite MPOs.
 function changebonds(ψ::DenseMPO, alg::SvdCut)
     return convert(DenseMPO, changebonds(convert(InfiniteMPS, ψ), alg))
 end

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -74,7 +74,7 @@ function find_groundstate(ψ::InfiniteMPS, H, alg::VUMPS, envs=environments(ψ, 
     return ψ, envs, ϵ
 end
 
-function _vumps_localupdate!(AC′, loc, ψ, H, envs, eigalg, factalg=QRpos())
+function _vumps_localupdate(loc, ψ, H, envs, eigalg, factalg=QRpos())
     AC′, C′ = @static if Defaults.parallelize_sites
         @sync begin
             Threads.@spawn begin

--- a/src/algorithms/statmech/vomps.jl
+++ b/src/algorithms/statmech/vomps.jl
@@ -60,12 +60,7 @@ function leading_boundary(ψ::MPSMultiline, O::MPOMultiline, alg::VOMPS,
                 end
             end
 
-            for row in 1:size(ψ, 1), col in 1:size(ψ, 2)
-                QAc, _ = leftorth!(temp_ACs[row, col]; alg=TensorKit.QRpos())
-                Qc, _ = leftorth!(temp_Cs[row, col]; alg=TensorKit.QRpos())
-                temp_ACs[row, col] = QAc * adjoint(Qc)
-            end
-
+            regauge!.(temp_ACs, temp_Cs; alg=TensorKit.QRpos())
             alg_gauge = updatetol(alg.alg_gauge, iter, ϵ)
             ψ = MPSMultiline(temp_ACs, ψ.CR[:, end]; alg_gauge.tol, alg_gauge.maxiter)
 

--- a/src/algorithms/statmech/vumps.jl
+++ b/src/algorithms/statmech/vumps.jl
@@ -57,12 +57,7 @@ function leading_boundary(ψ::MPSMultiline, H, alg::VUMPS, envs=environments(ψ,
                 end
             end
 
-            for row in 1:size(ψ, 1), col in 1:size(ψ, 2)
-                QAc, _ = leftorth!(temp_ACs[row, col]; alg=TensorKit.QRpos())
-                Qc, _ = leftorth!(temp_Cs[row, col]; alg=TensorKit.QRpos())
-                temp_ACs[row, col] = QAc * adjoint(Qc)
-            end
-
+            regauge!.(temp_ACs, temp_Cs; alg=TensorKit.QRpos())
             alg_gauge = updatetol(alg.alg_gauge, iter, ϵ)
             ψ = MPSMultiline(temp_ACs, ψ.CR[:, end]; alg_gauge.tol, alg_gauge.maxiter)
 

--- a/src/algorithms/timestep/tdvp.jl
+++ b/src/algorithms/timestep/tdvp.jl
@@ -18,76 +18,76 @@ algorithm for time evolution.
     finalize::F = Defaults._finalize
 end
 
-function timestep(Ψ::InfiniteMPS, H, t::Number, dt::Number, alg::TDVP,
-                  envs::Union{Cache,MultipleEnvironments}=environments(Ψ, H);
+function timestep(ψ::InfiniteMPS, H, t::Number, dt::Number, alg::TDVP,
+                  envs::Union{Cache,MultipleEnvironments}=environments(ψ, H);
                   leftorthflag=true)
-    temp_ACs = similar(Ψ.AC)
-    temp_CRs = similar(Ψ.CR)
-    @sync for (loc, (ac, c)) in enumerate(zip(Ψ.AC, Ψ.CR))
-        Threads.@spawn begin
-            h_ac = ∂∂AC(loc, Ψ, H, envs)
-            temp_ACs[loc] = integrate(h_ac, ac, t, dt, alg.integrator)
-        end
+    temp_ACs = similar(ψ.AC)
+    temp_CRs = similar(ψ.CR)
 
-        Threads.@spawn begin
-            h_c = ∂∂C(loc, Ψ, H, envs)
+    @static if Defaults.parallelize_sites
+        @sync for (loc, (ac, c)) in enumerate(zip(ψ.AC, ψ.CR))
+            Threads.@spawn begin
+                h_ac = ∂∂AC(loc, ψ, H, envs)
+                temp_ACs[loc] = integrate(h_ac, ac, t, dt, alg.integrator)
+            end
+
+            Threads.@spawn begin
+                h_c = ∂∂C(loc, ψ, H, envs)
+                temp_CRs[loc] = integrate(h_c, c, t, dt, alg.integrator)
+            end
+        end
+    else
+        for (loc, (ac, c)) in enumerate(zip(ψ.AC, ψ.CR))
+            h_ac = ∂∂AC(loc, ψ, H, envs)
+            temp_ACs[loc] = integrate(h_ac, ac, t, dt, alg.integrator)
+            h_c = ∂∂C(loc, ψ, H, envs)
             temp_CRs[loc] = integrate(h_c, c, t, dt, alg.integrator)
         end
     end
 
     if leftorthflag
-        for loc in 1:length(Ψ)
-            # find AL that best fits these new Acenter and centers
-            QAc, _ = leftorth!(temp_ACs[loc]; alg=TensorKit.QRpos())
-            Qc, _ = leftorth!(temp_CRs[loc]; alg=TensorKit.QRpos())
-            @plansor temp_ACs[loc][-1 -2; -3] = QAc[-1 -2; 1] * conj(Qc[-3; 1])
-        end
-        newΨ = InfiniteMPS(temp_ACs, Ψ.CR[end]; tol=alg.tolgauge, maxiter=alg.gaugemaxiter)
-
+        regauge!.(temp_ACs, temp_CRs; alg=TensorKit.QRpos())
+        ψ′ = InfiniteMPS(temp_ACs, ψ.CR[end]; tol=alg.tolgauge, maxiter=alg.gaugemaxiter)
     else
-        for loc in 1:length(Ψ)
-            # find AR that best fits these new Acenter and centers
-            _, QAc = rightorth!(_transpose_tail(temp_ACs[loc]); alg=TensorKit.LQpos())
-            _, Qc = rightorth!(temp_CRs[mod1(loc - 1, end)]; alg=TensorKit.LQpos())
-            temp_ACs[loc] = _transpose_front(Qc' * QAc)
-        end
-        newΨ = InfiniteMPS(Ψ.CR[0], temp_ACs; tol=alg.tolgauge, maxiter=alg.gaugemaxiter)
+        circshift!(temp_CRs, 1)
+        regauge!.(temp_CRs, temp_ACs; alg=TensorKit.LQpos())
+        ψ′ = InfiniteMPS(ψ.CR[0], temp_ACs; tol=alg.tolgauge, maxiter=alg.gaugemaxiter)
     end
 
-    recalculate!(envs, newΨ)
-    return newΨ, envs
+    recalculate!(envs, ψ′)
+    return ψ′, envs
 end
 
-function timestep!(Ψ::AbstractFiniteMPS, H, t::Number, dt::Number, alg::TDVP,
-                   envs::Union{Cache,MultipleEnvironments}=environments(Ψ, H))
+function timestep!(ψ::AbstractFiniteMPS, H, t::Number, dt::Number, alg::TDVP,
+                   envs::Union{Cache,MultipleEnvironments}=environments(ψ, H))
 
     # sweep left to right
-    for i in 1:(length(Ψ) - 1)
-        h_ac = ∂∂AC(i, Ψ, H, envs)
-        Ψ.AC[i] = integrate(h_ac, Ψ.AC[i], t, dt / 2, alg.integrator)
+    for i in 1:(length(ψ) - 1)
+        h_ac = ∂∂AC(i, ψ, H, envs)
+        ψ.AC[i] = integrate(h_ac, ψ.AC[i], t, dt / 2, alg.integrator)
 
-        h_c = ∂∂C(i, Ψ, H, envs)
-        Ψ.CR[i] = integrate(h_c, Ψ.CR[i], t, -dt / 2, alg.integrator)
+        h_c = ∂∂C(i, ψ, H, envs)
+        ψ.CR[i] = integrate(h_c, ψ.CR[i], t, -dt / 2, alg.integrator)
     end
 
     # edge case
-    h_ac = ∂∂AC(length(Ψ), Ψ, H, envs)
-    Ψ.AC[end] = integrate(h_ac, Ψ.AC[end], t, dt / 2, alg.integrator)
+    h_ac = ∂∂AC(length(ψ), ψ, H, envs)
+    ψ.AC[end] = integrate(h_ac, ψ.AC[end], t, dt / 2, alg.integrator)
 
     # sweep right to left
-    for i in length(Ψ):-1:2
-        h_ac = ∂∂AC(i, Ψ, H, envs)
-        Ψ.AC[i] = integrate(h_ac, Ψ.AC[i], t + dt / 2, dt / 2, alg.integrator)
+    for i in length(ψ):-1:2
+        h_ac = ∂∂AC(i, ψ, H, envs)
+        ψ.AC[i] = integrate(h_ac, ψ.AC[i], t + dt / 2, dt / 2, alg.integrator)
 
-        h_c = ∂∂C(i - 1, Ψ, H, envs)
-        Ψ.CR[i - 1] = integrate(h_c, Ψ.CR[i - 1], t + dt / 2, -dt / 2, alg.integrator)
+        h_c = ∂∂C(i - 1, ψ, H, envs)
+        ψ.CR[i - 1] = integrate(h_c, ψ.CR[i - 1], t + dt / 2, -dt / 2, alg.integrator)
     end
 
     # edge case
-    h_ac = ∂∂AC(1, Ψ, H, envs)
-    Ψ.AC[1] = integrate(h_ac, Ψ.AC[1], t + dt / 2, dt / 2, alg.integrator)
+    h_ac = ∂∂AC(1, ψ, H, envs)
+    ψ.AC[1] = integrate(h_ac, ψ.AC[1], t + dt / 2, dt / 2, alg.integrator)
 
-    return Ψ, envs
+    return ψ, envs
 end
 
 """
@@ -112,46 +112,46 @@ algorithm for time evolution.
     finalize::F = Defaults._finalize
 end
 
-function timestep!(Ψ::AbstractFiniteMPS, H, t::Number, dt::Number, alg::TDVP2,
-                   envs=environments(Ψ, H))
+function timestep!(ψ::AbstractFiniteMPS, H, t::Number, dt::Number, alg::TDVP2,
+                   envs=environments(ψ, H))
 
     # sweep left to right
-    for i in 1:(length(Ψ) - 1)
-        ac2 = _transpose_front(Ψ.AC[i]) * _transpose_tail(Ψ.AR[i + 1])
-        h_ac2 = ∂∂AC2(i, Ψ, H, envs)
+    for i in 1:(length(ψ) - 1)
+        ac2 = _transpose_front(ψ.AC[i]) * _transpose_tail(ψ.AR[i + 1])
+        h_ac2 = ∂∂AC2(i, ψ, H, envs)
         nac2 = integrate(h_ac2, ac2, t, dt / 2, alg.integrator)
 
         nal, nc, nar = tsvd!(nac2; trunc=alg.trscheme, alg=TensorKit.SVD())
-        Ψ.AC[i] = (nal, complex(nc))
-        Ψ.AC[i + 1] = (complex(nc), _transpose_front(nar))
+        ψ.AC[i] = (nal, complex(nc))
+        ψ.AC[i + 1] = (complex(nc), _transpose_front(nar))
 
-        if i != (length(Ψ) - 1)
-            Ψ.AC[i + 1] = integrate(∂∂AC(i + 1, Ψ, H, envs), Ψ.AC[i + 1], t, -dt / 2,
+        if i != (length(ψ) - 1)
+            ψ.AC[i + 1] = integrate(∂∂AC(i + 1, ψ, H, envs), ψ.AC[i + 1], t, -dt / 2,
                                     alg.integrator)
         end
     end
 
     # sweep right to left
-    for i in length(Ψ):-1:2
-        ac2 = _transpose_front(Ψ.AL[i - 1]) * _transpose_tail(Ψ.AC[i])
-        h_ac2 = ∂∂AC2(i - 1, Ψ, H, envs)
+    for i in length(ψ):-1:2
+        ac2 = _transpose_front(ψ.AL[i - 1]) * _transpose_tail(ψ.AC[i])
+        h_ac2 = ∂∂AC2(i - 1, ψ, H, envs)
         nac2 = integrate(h_ac2, ac2, t + dt / 2, dt / 2, alg.integrator)
 
         nal, nc, nar = tsvd!(nac2; trunc=alg.trscheme, alg=TensorKit.SVD())
-        Ψ.AC[i - 1] = (nal, complex(nc))
-        Ψ.AC[i] = (complex(nc), _transpose_front(nar))
+        ψ.AC[i - 1] = (nal, complex(nc))
+        ψ.AC[i] = (complex(nc), _transpose_front(nar))
 
         if i != 2
-            Ψ.AC[i - 1] = integrate(∂∂AC(i - 1, Ψ, H, envs), Ψ.AC[i - 1], t + dt / 2,
+            ψ.AC[i - 1] = integrate(∂∂AC(i - 1, ψ, H, envs), ψ.AC[i - 1], t + dt / 2,
                                     -dt / 2, alg.integrator)
         end
     end
 
-    return Ψ, envs
+    return ψ, envs
 end
 
 #copying version
-function timestep(Ψ::AbstractFiniteMPS, H, time::Number, timestep::Number,
-                  alg::Union{TDVP,TDVP2}, envs=environments(Ψ, H); kwargs...)
-    return timestep!(copy(Ψ), H, time, timestep, alg, envs; kwargs...)
+function timestep(ψ::AbstractFiniteMPS, H, time::Number, timestep::Number,
+                  alg::Union{TDVP,TDVP2}, envs=environments(ψ, H); kwargs...)
+    return timestep!(copy(ψ), H, time, timestep, alg, envs; kwargs...)
 end

--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -64,6 +64,20 @@ function MPSTensor(A::AbstractArray{T}) where {T<:Number}
     return t
 end
 
+"""
+    isfullrank(A::GenericMPSTensor)
+
+Determine whether the given tensor is full rank, i.e. whether both the map from the left
+virtual space and the physical space to the right virtual space, and the map from the right
+virtual space and the physical space to the left virtual space are injective.
+"""
+function isfullrank(A::GenericMPSTensor)
+    Vₗ = _firstspace(A)
+    Vᵣ = _lastspace(A)
+    P = ⊗(space.(Ref(A), 2:(numind(A) - 1))...)
+    return Vₗ ⊗ P ≿ Vᵣ' && Vₗ' ≾ P ⊗ Vᵣ
+end
+
 #===========================================================================================
 MPS types
 ===========================================================================================#

--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -65,17 +65,46 @@ function MPSTensor(A::AbstractArray{T}) where {T<:Number}
 end
 
 """
-    isfullrank(A::GenericMPSTensor)
+    isfullrank(A::GenericMPSTensor; side=:both)
 
 Determine whether the given tensor is full rank, i.e. whether both the map from the left
 virtual space and the physical space to the right virtual space, and the map from the right
 virtual space and the physical space to the left virtual space are injective.
 """
-function isfullrank(A::GenericMPSTensor)
+function isfullrank(A::GenericMPSTensor; side=:both)
     Vₗ = _firstspace(A)
     Vᵣ = _lastspace(A)
     P = ⊗(space.(Ref(A), 2:(numind(A) - 1))...)
-    return Vₗ ⊗ P ≿ Vᵣ' && Vₗ' ≾ P ⊗ Vᵣ
+    return if side === :both
+        Vₗ ⊗ P ≿ Vᵣ' && Vₗ' ≾ P ⊗ Vᵣ
+    elseif side === :right
+        Vₗ ⊗ P ≿ Vᵣ'
+    elseif side === :left
+        Vₗ' ≾ P ⊗ Vᵣ
+    else
+        throw(ArgumentError("Invalid side: $side"))
+    end
+end
+
+"""
+    makefullrank!(A::PeriodicVector{<:GenericMPSTensor}; alg=QRpos())
+
+Make the set of MPS tensors full rank by performing a series of orthogonalizations.
+"""
+function makefullrank!(A::PeriodicVector{<:GenericMPSTensor}; alg=QRpos())
+    while true
+        i = findfirst(!isfullrank, A)
+        isnothing(i) && break
+        if !isfullrank(A[i]; side=:left)
+            L, Q = rightorth!(_transpose_tail(A[i]); alg=alg')
+            A[i] = _transpose_front(Q)
+            A[i - 1] = A[i - 1] * L
+        else
+            A[i], R = leftorth!(A[i]; alg)
+            A[i + 1] = _transpose_front(R * _transpose_tail(A[i + 1]))
+        end
+    end
+    return A
 end
 
 #===========================================================================================

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -167,7 +167,7 @@ function InfiniteMPS(A::AbstractVector{<:GenericMPSTensor}; kwargs...)
     ψ = InfiniteMPS{eltype(AL),eltype(CR)}(AL, AR, CR, AC)
 
     # gaugefix the MPS
-    uniform_gaugefix!(ψ, A_copy, C₀; kwargs...)
+    gaugefix!(ψ, A_copy, C₀; kwargs...)
     mul!.(ψ.AC, ψ.AL, ψ.CR)
 
     return ψ
@@ -183,7 +183,7 @@ function InfiniteMPS(AL::AbstractVector{<:GenericMPSTensor}, C₀::MPSBondTensor
     ψ = InfiniteMPS{eltype(AL),eltype(CR)}(AL, AR, CR, AC)
 
     # gaugefix the MPS
-    uniform_gaugefix!(ψ, AL, C₀; order=:R, kwargs...)
+    gaugefix!(ψ, AL, C₀; order=:R, kwargs...)
     mul!.(ψ.AC, ψ.AL, ψ.CR)
 
     return ψ
@@ -199,7 +199,7 @@ function InfiniteMPS(C₀::MPSBondTensor, AR::AbstractVector{<:GenericMPSTensor}
     ψ = InfiniteMPS{eltype(AL),eltype(CR)}(AL, AR, CR, AC)
 
     # gaugefix the MPS
-    uniform_gaugefix!(ψ, AR, C₀; order=:L, kwargs...)
+    gaugefix!(ψ, AR, C₀; order=:L, kwargs...)
     mul!.(ψ.AC, ψ.AL, ψ.CR)
 
     return ψ

--- a/src/states/ortho.jl
+++ b/src/states/ortho.jl
@@ -87,7 +87,7 @@ function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀=ψ.CR[end]; order=:LR, kwarg
     else
         throw(ArgumentError("Invalid order: $order"))
     end
-    
+
     return uniform_gaugefix!(ψ, A, C₀, alg)
 end
 
@@ -126,7 +126,7 @@ function uniform_leftorth!((AL, CR), A, C₀, alg::LeftCanonical)
         state = (; AL, CR, A, A_tail, CA_tail, iter=0, ϵ=Inf)
         it = IterativeSolver(alg, state)
         loginit!(log, it.ϵ)
-        
+
         # iteratively solve
         for (AL, CR) in it
             iter, ϵ = it.iter, it.ϵ
@@ -146,10 +146,10 @@ function Base.iterate(it::IterativeSolver{LeftCanonical}, state=it.state)
     C₀ = gauge_eigsolve_step!(it, state)
     C₁ = gauge_orth_step!(it, state)
     ϵ = oftype(state.ϵ, norm(C₀ - C₁))
-    
+
     iter = state.iter + 1
     it.state = (; state.AL, state.CR, state.A, state.A_tail, state.CA_tail, iter, ϵ)
-    
+
     return (it.state.AL, it.state.CR), it.state
 end
 
@@ -183,7 +183,7 @@ function uniform_rightorth!((AR, CR), A, C₀, alg::RightCanonical)
         state = (; AR, CR, A, AC_tail, iter=0, ϵ=Inf)
         it = IterativeSolver(alg, state)
         loginit!(log, it.ϵ)
-        
+
         # iteratively solve
         for (AR, CR) in it
             iter, ϵ = it.iter, it.ϵ
@@ -203,10 +203,10 @@ function Base.iterate(it::IterativeSolver{RightCanonical}, state=it.state)
     C₀ = gauge_eigsolve_step!(it, state)
     C₁ = gauge_orth_step!(it, state)
     ϵ = oftype(state.ϵ, norm(C₀ - C₁))
-    
+
     iter = state.iter + 1
     it.state = (; state.AR, state.CR, state.A, state.AC_tail, iter, ϵ)
-    
+
     return (it.state.AR, it.state.CR), it.state
 end
 

--- a/src/states/ortho.jl
+++ b/src/states/ortho.jl
@@ -1,78 +1,233 @@
-"
-solves AL * C = C * A in-place
-"
-function uniform_leftorth!(AL, CR, A; tol=Defaults.tolgauge, maxiter=Defaults.maxiter)
-    #(_,CR[end]) = leftorth!(CR[end], alg = TensorKit.QRpos());
-    normalize!(CR[end])
+# Algorithms
+# ----------
 
-    iteration = 1
-    delta = 2 * tol
+const _GAUGE_ALG_EIGSOLVE = DynamicTol(Arnoldi(; krylovdim=30, eager=true),
+                                       Defaults.tolgauge / 10, Inf, 1)
 
-    while iteration < maxiter && delta > tol
-        if iteration > 10 #when qr starts to fail, start using eigs - should be kw arg
-            alg = Arnoldi(; krylovdim=30, tol=max(delta * delta, tol / 10), maxiter=maxiter)
+"""
+    struct LeftCanonical <: Algorithm
 
-            (vals, vecs) = eigsolve(flip(TransferMatrix(A, AL)), CR[end], 1, :LM, alg)
-            (_, CR[end]) = leftorth!(vecs[1]; alg=TensorKit.QRpos())
-        end
+Algorithm for bringing an `InfiniteMPS` into the left-canonical form.
+"""
+@kwdef struct LeftCanonical <: Algorithm
+    tol::Float64 = Defaults.tolgauge
+    maxiter::Int = Defaults.maxiter
+    verbosity::Int = VERBOSE_WARN
 
-        cold = CR[end]
-
-        for loc in 1:length(AL)
-            AL[loc] = _transpose_front(CR[mod1(loc - 1, end)] * _transpose_tail(A[loc]))
-            AL[loc], CR[loc] = leftorth!(AL[loc]; alg=QRpos())
-            normalize!(CR[loc])
-        end
-
-        #update delta
-        if domain(cold) == domain(CR[end]) && codomain(cold) == codomain(CR[end])
-            delta = norm(cold - CR[end])
-        end
-
-        iteration += 1
-    end
-
-    delta > tol && @warn "leftorth failed to converge $(delta)"
-
-    return AL, CR
+    alg_orth = QRpos()
+    alg_eigsolve = _GAUGE_ALG_EIGSOLVE
+    eig_miniter::Int = 10
 end
 
-"
-solves C * AR = C * A in-place
-"
-function uniform_rightorth!(AR, CR, A; tol=Defaults.tolgauge, maxiter=Defaults.maxiter)
-    #(CR[end],_) = rightorth!(CR[end], alg = TensorKit.LQpos());
-    normalize!(CR[end])
+"""
+    struct RightCanonical <: Algorithm
 
-    iteration = 1
-    delta = 2 * tol
-    while iteration < maxiter && delta > tol
-        if iteration > 10#when qr starts to fail, start using eigs
-            alg = Arnoldi(; krylovdim=30, tol=max(delta * delta, tol / 10), maxiter=maxiter)
-            #Projection of the current guess onto its largest self consistent eigenvector + isolation of the unitary part
+Algorithm for bringing an `InfiniteMPS` into the right-canonical form.
+"""
+@kwdef struct RightCanonical <: Algorithm
+    tol::Float64 = Defaults.tolgauge
+    maxiter::Int = Defaults.maxiter
+    verbosity::Int = VERBOSE_WARN
 
-            (vals, vecs) = eigsolve(TransferMatrix(A, AR), CR[end], 1, :LM, alg)
-            (CR[end], _) = rightorth!(vecs[1]; alg=TensorKit.LQpos())
-        end
+    alg_orth = LQpos()
+    alg_eigsolve = _GAUGE_ALG_EIGSOLVE
+    eig_miniter::Int = 10
+end
 
-        cold = CR[end]
-        for loc in length(AR):-1:1
-            AR[loc] = A[loc] * CR[loc]
+"""
+    struct MixedCanonical <: Algorithm
 
-            CR[mod1(loc - 1, end)], temp = rightorth!(_transpose_tail(AR[loc]); alg=LQpos())
-            AR[loc] = _transpose_front(temp)
-            normalize!(CR[mod1(loc - 1, end)])
-        end
+"""
+struct MixedCanonical <: Algorithm
+    alg_leftcanonical::LeftCanonical
+    alg_rightcanonical::RightCanonical
+    order::Symbol
+end
 
-        #update counters and delta
-        if domain(cold) == domain(CR[end]) && codomain(cold) == codomain(CR[end])
-            delta = norm(cold - CR[end])
-        end
-
-        iteration += 1
+function MixedCanonical(; tol::Real=Defaults.tolgauge, maxiter::Int=Defaults.maxiter,
+                        verbosity::Int=VERBOSE_WARN, alg_orth=QRpos(),
+                        alg_eigsolve=_GAUGE_ALG_EIGSOLVE,
+                        eig_miniter::Int=10, order::Symbol=:LR)
+    if alg_orth isa QR || alg_orth isa QRpos
+        alg_leftorth = alg_orth
+        alg_rightorth = alg_orth'
+    elseif alg_orth isa LQ || alg_orth isa LQpos
+        alg_leftorth = alg_orth'
+        alg_rightorth = alg_orth
+    else
+        throw(ArgumentError("Invalid orthogonalization algorithm: $(typeof(alg_orth))"))
     end
 
-    delta > tol && @warn "rightorth failed to converge $(delta)"
+    left = LeftCanonical(; tol, maxiter, verbosity, alg_orth=alg_leftorth,
+                         alg_eigsolve, eig_miniter)
+    right = RightCanonical(; tol, maxiter=maxiter, verbosity, alg_orth=alg_rightorth,
+                           alg_eigsolve, eig_miniter)
 
-    return AR, CR
+    return MixedCanonical(left, right, order)
+end
+
+# Interface
+# ---------
+
+@doc """
+    uniform_gaugefix!(ψ::InfiniteMPS, A, C₀; kwargs...) -> ψ
+    uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::Algorithm) -> ψ
+
+Bring an `InfiniteMPS` into a uniform gauge, using the specified algorithm.
+"""
+uniform_gaugefix!
+
+function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀=ψ.CR[end]; order=:LR, kwargs...)
+    alg = if order === :LR || order === :RL
+        MixedCanonical(; order, kwargs...)
+    elseif order === :L
+        LeftCanonical(; kwargs...)
+    elseif order === :R
+        RightCanonical(; kwargs...)
+    else
+        throw(ArgumentError("Invalid order: $order"))
+    end
+    
+    return uniform_gaugefix!(ψ, A, C₀, alg)
+end
+
+# expert mode: actual implementation
+function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::MixedCanonical)
+    if alg.order === :LR
+        uniform_gaugefix!(ψ, A, C₀, alg.alg_leftcanonical)
+        uniform_gaugefix!(ψ, ψ.AL, ψ.CR[end], alg.alg_rightcanonical)
+    elseif alg.order === :RL
+        uniform_gaugefix!(ψ, A, C₀, alg.alg_rightcanonical)
+        uniform_gaugefix!(ψ, ψ.AR, ψ.CR[end], alg.alg_leftcanonical)
+    else
+        throw(ArgumentError("Invalid order: $(alg.order)"))
+    end
+    return ψ
+end
+function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::LeftCanonical)
+    uniform_leftorth!((ψ.AL, ψ.CR), A, C₀, alg)
+    return ψ
+end
+function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::RightCanonical)
+    uniform_rightorth!((ψ.AR, ψ.CR), A, C₀, alg)
+    return ψ
+end
+
+# Implementation
+# --------------
+
+function uniform_leftorth!((AL, CR), A, C₀, alg::LeftCanonical)
+    CR[end] = normalize!(C₀)
+    return LoggingExtras.withlevel(; alg.verbosity) do
+        # initialize algorithm and temporary variables
+        log = IterLog("LC")
+        A_tail = _transpose_tail.(A) # pre-transpose A
+        CA_tail = similar.(A_tail)  # pre-allocate workspace
+        state = (; AL, CR, A, A_tail, CA_tail, iter=0, ϵ=Inf)
+        it = IterativeSolver(alg, state)
+        loginit!(log, it.ϵ)
+        
+        # iteratively solve
+        for (AL, CR) in it
+            iter, ϵ = it.iter, it.ϵ
+            if ϵ < it.tol
+                @infov 2 logfinish!(log, iter, ϵ)
+                return AL, CR
+            elseif iter > it.maxiter
+                @warnv 2 logcancel!(log, iter, ϵ)
+                return AL, CR
+            end
+            @infov 3 logiter!(log, iter, ϵ)
+        end
+    end
+end
+
+function Base.iterate(it::IterativeSolver{LeftCanonical}, state=it.state)
+    C₀ = gauge_eigsolve_step!(it, state)
+    C₁ = gauge_orth_step!(it, state)
+    ϵ = oftype(state.ϵ, norm(C₀ - C₁))
+    
+    iter = state.iter + 1
+    it.state = (; state.AL, state.CR, state.A, state.A_tail, state.CA_tail, iter, ϵ)
+    
+    return (it.state.AL, it.state.CR), it.state
+end
+
+function gauge_eigsolve_step!(it::IterativeSolver{LeftCanonical}, state)
+    (; AL, CR, A, iter, ϵ) = state
+    if iter ≥ it.eig_miniter
+        alg_eigsolve = updatetol(it.alg_eigsolve, 1, ϵ^2)
+        _, vecs = eigsolve(flip(TransferMatrix(A, AL)), CR[end], 1, :LM, alg_eigsolve)
+        _, CR[end] = leftorth!(vecs[1]; alg=it.alg_orth)
+    end
+    return CR[end]
+end
+
+function gauge_orth_step!(it::IterativeSolver{LeftCanonical}, state)
+    (; AL, CR, A_tail, CA_tail) = state
+    for i in 1:length(AL)
+        mul!(CA_tail[i], CR[i - 1], A_tail[i])
+        _repartition!(AL[i], CA_tail[i])
+        AL[i], CR[i] = leftorth!(AL[i]; alg=it.alg_orth)
+    end
+    normalize!(CR[end])
+    return CR[end]
+end
+
+function uniform_rightorth!((AR, CR), A, C₀, alg::RightCanonical)
+    CR[end] = normalize!(C₀)
+    return LoggingExtras.withlevel(; alg.verbosity) do
+        # initialize algorithm and temporary variables
+        log = IterLog("RC")
+        AC_tail = _similar_tail.(A) # pre-allocate workspace
+        state = (; AR, CR, A, AC_tail, iter=0, ϵ=Inf)
+        it = IterativeSolver(alg, state)
+        loginit!(log, it.ϵ)
+        
+        # iteratively solve
+        for (AR, CR) in it
+            iter, ϵ = it.iter, it.ϵ
+            if ϵ < it.tol
+                @infov 2 logfinish!(log, iter, ϵ)
+                return AR, CR
+            elseif iter > it.maxiter
+                @warnv 2 logcancel!(log, iter, ϵ)
+                return AR, CR
+            end
+            @infov 3 logiter!(log, iter, ϵ)
+        end
+    end
+end
+
+function Base.iterate(it::IterativeSolver{RightCanonical}, state=it.state)
+    C₀ = gauge_eigsolve_step!(it, state)
+    C₁ = gauge_orth_step!(it, state)
+    ϵ = oftype(state.ϵ, norm(C₀ - C₁))
+    
+    iter = state.iter + 1
+    it.state = (; state.AR, state.CR, state.A, state.AC_tail, iter, ϵ)
+    
+    return (it.state.AR, it.state.CR), it.state
+end
+
+function gauge_eigsolve_step!(it::IterativeSolver{RightCanonical}, state)
+    (; AR, CR, A, iter, ϵ) = state
+    if iter ≥ it.eig_miniter
+        alg_eigsolve = updatetol(it.alg_eigsolve, 1, ϵ^2)
+        _, vecs = eigsolve(TransferMatrix(A, AR), CR[end], 1, :LM, alg_eigsolve)
+        CR[end], _ = rightorth!(vecs[1]; alg=it.alg_orth)
+    end
+    return CR[end]
+end
+
+function gauge_orth_step!(it::IterativeSolver{RightCanonical}, state)
+    (; A, AR, CR, AC_tail) = state
+    for i in length(AR):-1:1
+        AC = mul!(AR[i], A[i], CR[i])   # use AR as temporary storage for A * C
+        tmp = _repartition!(AC_tail[i], AC)
+        CR[i - 1], tmp = rightorth!(tmp; alg=it.alg_orth)
+        _repartition!(AR[i], tmp)       # TODO: avoid doing this every iteration
+    end
+    normalize!(CR[end])
+    return CR[end]
 end

--- a/src/states/ortho.jl
+++ b/src/states/ortho.jl
@@ -70,14 +70,14 @@ end
 # ---------
 
 @doc """
-    uniform_gaugefix!(ψ::InfiniteMPS, A, C₀; kwargs...) -> ψ
-    uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::Algorithm) -> ψ
+    gaugefix!(ψ::InfiniteMPS, A, C₀; kwargs...) -> ψ
+    gaugefix!(ψ::InfiniteMPS, A, C₀, alg::Algorithm) -> ψ
 
 Bring an `InfiniteMPS` into a uniform gauge, using the specified algorithm.
 """
-uniform_gaugefix!
+gaugefix!
 
-function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀=ψ.CR[end]; order=:LR, kwargs...)
+function gaugefix!(ψ::InfiniteMPS, A, C₀=ψ.CR[end]; order=:LR, kwargs...)
     alg = if order === :LR || order === :RL
         MixedCanonical(; order, kwargs...)
     elseif order === :L
@@ -88,27 +88,27 @@ function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀=ψ.CR[end]; order=:LR, kwarg
         throw(ArgumentError("Invalid order: $order"))
     end
 
-    return uniform_gaugefix!(ψ, A, C₀, alg)
+    return gaugefix!(ψ, A, C₀, alg)
 end
 
 # expert mode: actual implementation
-function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::MixedCanonical)
+function gaugefix!(ψ::InfiniteMPS, A, C₀, alg::MixedCanonical)
     if alg.order === :LR
-        uniform_gaugefix!(ψ, A, C₀, alg.alg_leftcanonical)
-        uniform_gaugefix!(ψ, ψ.AL, ψ.CR[end], alg.alg_rightcanonical)
+        gaugefix!(ψ, A, C₀, alg.alg_leftcanonical)
+        gaugefix!(ψ, ψ.AL, ψ.CR[end], alg.alg_rightcanonical)
     elseif alg.order === :RL
-        uniform_gaugefix!(ψ, A, C₀, alg.alg_rightcanonical)
-        uniform_gaugefix!(ψ, ψ.AR, ψ.CR[end], alg.alg_leftcanonical)
+        gaugefix!(ψ, A, C₀, alg.alg_rightcanonical)
+        gaugefix!(ψ, ψ.AR, ψ.CR[end], alg.alg_leftcanonical)
     else
         throw(ArgumentError("Invalid order: $(alg.order)"))
     end
     return ψ
 end
-function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::LeftCanonical)
+function gaugefix!(ψ::InfiniteMPS, A, C₀, alg::LeftCanonical)
     uniform_leftorth!((ψ.AL, ψ.CR), A, C₀, alg)
     return ψ
 end
-function uniform_gaugefix!(ψ::InfiniteMPS, A, C₀, alg::RightCanonical)
+function gaugefix!(ψ::InfiniteMPS, A, C₀, alg::RightCanonical)
     uniform_rightorth!((ψ.AR, ψ.CR), A, C₀, alg)
     return ψ
 end

--- a/src/utility/iterativesolvers.jl
+++ b/src/utility/iterativesolvers.jl
@@ -1,0 +1,19 @@
+# This file contains the definition of the IterativeSolver type and the solve! function.
+# Attempts to remove as much of the boilerplate code as possible from the iterative solvers.
+
+mutable struct IterativeSolver{A,B<:NamedTuple}
+    alg::A
+    state::B
+end
+
+function Base.getproperty(it::IterativeSolver{A,B}, name::Symbol) where {A,B}
+    name === :alg || name === :state && return getfield(it, name)
+
+    alg = getfield(it, :alg)
+    name in propertynames(alg) && return getproperty(alg, name)
+
+    state = getfield(it, :state)
+    name in propertynames(state) && return getproperty(state, name)
+
+    throw(ArgumentError("Field $name not found in IterativeSolver"))
+end

--- a/src/utility/logging.jl
+++ b/src/utility/logging.jl
@@ -36,9 +36,11 @@ function loginit!(log::IterLog, error::Float64,
                   objective::Union{Nothing,Number}=nothing)
     log.iter = 0
     log.error = error
-
-    warnapproxreal(objective)
-    log.objective = real(objective)
+    
+    if !isnothing(objective)
+        warnapproxreal(objective)
+        log.objective = real(objective)
+    end
 
     log.t_init = log.t_prev = log.t_last = Base.time()
     log.state = INIT
@@ -51,8 +53,10 @@ function logiter!(log::IterLog, iter::Int, error::Float64,
     log.iter = iter
     log.error = error
 
-    warnapproxreal(objective)
-    log.objective = real(objective)
+    if !isnothing(objective)
+        warnapproxreal(objective)
+        log.objective = real(objective)
+    end
 
     log.t_prev = log.t_last
     log.t_last = Base.time()
@@ -66,8 +70,10 @@ function logfinish!(log::IterLog, iter::Int, error::Float64,
     log.iter = iter
     log.error = error
 
-    warnapproxreal(objective)
-    log.objective = real(objective)
+    if !isnothing(objective)
+        warnapproxreal(objective)
+        log.objective = real(objective)
+    end
 
     log.t_prev = log.t_last
     log.t_last = Base.time()
@@ -81,8 +87,10 @@ function logcancel!(log::IterLog, iter::Int, error::Float64,
     log.iter = iter
     log.error = error
 
-    warnapproxreal(objective)
-    log.objective = real(objective)
+    if !isnothing(objective)
+        warnapproxreal(objective)
+        log.objective = real(objective)
+    end
 
     log.t_prev = log.t_last
     log.t_last = Base.time()

--- a/src/utility/logging.jl
+++ b/src/utility/logging.jl
@@ -36,7 +36,7 @@ function loginit!(log::IterLog, error::Float64,
                   objective::Union{Nothing,Number}=nothing)
     log.iter = 0
     log.error = error
-    
+
     if !isnothing(objective)
         warnapproxreal(objective)
         log.objective = real(objective)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -260,7 +260,7 @@ end
         H = MPOHamiltonian(nn)
         Δt = 0.1
         expH = make_time_mpo(H, Δt, WII())
-        
+
         O = convert(DenseMPO, expH)
         Op = periodic_boundary_conditions(O, 10)
         Op′ = changebonds(Op, SvdCut(; trscheme=truncdim(5)))
@@ -268,75 +268,75 @@ end
         @test dim(space(Op′[5], 1)) < dim(space(Op[5], 1))
     end
 
-    # @testset "infinite mps" begin
-    #     #random nn interaction
-    #     nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
-    #     nn += nn'
+    @testset "infinite mps" begin
+        #random nn interaction
+        nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
+        nn += nn'
 
-    #     state = InfiniteMPS([pspace, pspace], [Dspace, Dspace])
+        state = InfiniteMPS([pspace, pspace], [Dspace, Dspace])
 
-    #     state_re = changebonds(state,
-    #                            RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-    #     @test dot(state, state_re) ≈ 1 atol = 1e-8
+        state_re = changebonds(state,
+                               RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+        @test dot(state, state_re) ≈ 1 atol = 1e-8
 
-    #     state_oe, _ = changebonds(state,
-    #                               repeat(MPOHamiltonian(nn), 2),
-    #                               OptimalExpand(;
-    #                                             trscheme=truncdim(dim(Dspace) *
-    #                                                               dim(Dspace))))
-    #     @test dot(state, state_oe) ≈ 1 atol = 1e-8
+        state_oe, _ = changebonds(state,
+                                  repeat(MPOHamiltonian(nn), 2),
+                                  OptimalExpand(;
+                                                trscheme=truncdim(dim(Dspace) *
+                                                                  dim(Dspace))))
+        @test dot(state, state_oe) ≈ 1 atol = 1e-8
 
-    #     state_vs, _ = changebonds(state, repeat(MPOHamiltonian(nn), 2),
-    #                               VUMPSSvdCut(; trscheme=notrunc()))
-    #     @test dim(left_virtualspace(state, 1)) < dim(left_virtualspace(state_vs, 1))
+        state_vs, _ = changebonds(state, repeat(MPOHamiltonian(nn), 2),
+                                  VUMPSSvdCut(; trscheme=notrunc()))
+        @test dim(left_virtualspace(state, 1)) < dim(left_virtualspace(state_vs, 1))
 
-    #     state_vs_tr = changebonds(state_vs, SvdCut(; trscheme=truncdim(dim(Dspace))))
-    #     @test dim(right_virtualspace(state_vs_tr, 1)) < dim(right_virtualspace(state_vs, 1))
-    # end
+        state_vs_tr = changebonds(state_vs, SvdCut(; trscheme=truncdim(dim(Dspace))))
+        @test dim(right_virtualspace(state_vs_tr, 1)) < dim(right_virtualspace(state_vs, 1))
+    end
 
-    # @testset "finite mps" begin
-    #     #random nn interaction
-    #     nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
-    #     nn += nn'
+    @testset "finite mps" begin
+        #random nn interaction
+        nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
+        nn += nn'
 
-    #     state = FiniteMPS(10, pspace, Dspace)
+        state = FiniteMPS(10, pspace, Dspace)
 
-    #     state_re = changebonds(state,
-    #                            RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-    #     @test dot(state, state_re) ≈ 1 atol = 1e-8
+        state_re = changebonds(state,
+                               RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+        @test dot(state, state_re) ≈ 1 atol = 1e-8
 
-    #     state_oe, _ = changebonds(state, MPOHamiltonian(nn),
-    #                               OptimalExpand(;
-    #                                             trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-    #     @test dot(state, state_oe) ≈ 1 atol = 1e-8
+        state_oe, _ = changebonds(state, MPOHamiltonian(nn),
+                                  OptimalExpand(;
+                                                trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+        @test dot(state, state_oe) ≈ 1 atol = 1e-8
 
-    #     state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
+        state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
 
-    #     @test dim(left_virtualspace(state_tr, 5)) < dim(right_virtualspace(state_oe, 5))
-    # end
+        @test dim(left_virtualspace(state_tr, 5)) < dim(right_virtualspace(state_oe, 5))
+    end
 
-    # @testset "MPSMultiline" begin
-    #     o = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
-    #     mpo = MPOMultiline(o)
+    @testset "MPSMultiline" begin
+        o = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
+        mpo = MPOMultiline(o)
 
-    #     t = TensorMap(rand, ComplexF64, Dspace * pspace, Dspace)
-    #     state = MPSMultiline(fill(t, 1, 1))
+        t = TensorMap(rand, ComplexF64, Dspace * pspace, Dspace)
+        state = MPSMultiline(fill(t, 1, 1))
 
-    #     state_re = changebonds(state,
-    #                            RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-    #     @test dot(state, state_re) ≈ 1 atol = 1e-8
+        state_re = changebonds(state,
+                               RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+        @test dot(state, state_re) ≈ 1 atol = 1e-8
 
-    #     state_oe, _ = changebonds(state, mpo,
-    #                               OptimalExpand(;
-    #                                             trscheme=truncdim(dim(Dspace) *
-    #                                                               dim(Dspace))))
-    #     @test dot(state, state_oe) ≈ 1 atol = 1e-8
+        state_oe, _ = changebonds(state, mpo,
+                                  OptimalExpand(;
+                                                trscheme=truncdim(dim(Dspace) *
+                                                                  dim(Dspace))))
+        @test dot(state, state_oe) ≈ 1 atol = 1e-8
 
-    #     state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
+        state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
 
-    #     @test dim(right_virtualspace(state_tr, 1, 1)) <
-    #           dim(left_virtualspace(state_oe, 1, 1))
-    # end
+        @test dim(right_virtualspace(state_tr, 1, 1)) <
+              dim(left_virtualspace(state_oe, 1, 1))
+    end
 end
 
 @testset "Dynamical DMRG" verbose = true begin

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -257,84 +257,86 @@ end
         #random nn interaction
         nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
         nn += nn'
+        H = MPOHamiltonian(nn)
+        Δt = 0.1
+        expH = make_time_mpo(H, Δt, WII())
+        
+        O = convert(DenseMPO, expH)
+        Op = periodic_boundary_conditions(O, 10)
+        Op′ = changebonds(Op, SvdCut(; trscheme=truncdim(5)))
 
-        mpo1 = periodic_boundary_conditions(convert(DenseMPO,
-                                                    make_time_mpo(MPOHamiltonian(nn), 0.1,
-                                                                  WII())), 10)
-        mpo2 = changebonds(mpo1, SvdCut(; trscheme=truncdim(5)))
-
-        @test dim(space(mpo2[5], 1)) < dim(space(mpo1[5], 1))
+        @test dim(space(Op′[5], 1)) < dim(space(Op[5], 1))
     end
 
-    @testset "infinite mps" begin
-        #random nn interaction
-        nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
-        nn += nn'
+    # @testset "infinite mps" begin
+    #     #random nn interaction
+    #     nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
+    #     nn += nn'
 
-        state = InfiniteMPS([pspace, pspace], [Dspace, Dspace])
+    #     state = InfiniteMPS([pspace, pspace], [Dspace, Dspace])
 
-        state_re = changebonds(state,
-                               RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-        @test dot(state, state_re) ≈ 1 atol = 1e-8
+    #     state_re = changebonds(state,
+    #                            RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+    #     @test dot(state, state_re) ≈ 1 atol = 1e-8
 
-        state_oe, _ = changebonds(state,
-                                  repeat(MPOHamiltonian(nn), 2),
-                                  OptimalExpand(;
-                                                trscheme=truncdim(dim(Dspace) *
-                                                                  dim(Dspace))))
-        @test dot(state, state_oe) ≈ 1 atol = 1e-8
+    #     state_oe, _ = changebonds(state,
+    #                               repeat(MPOHamiltonian(nn), 2),
+    #                               OptimalExpand(;
+    #                                             trscheme=truncdim(dim(Dspace) *
+    #                                                               dim(Dspace))))
+    #     @test dot(state, state_oe) ≈ 1 atol = 1e-8
 
-        state_vs, _ = changebonds(state, repeat(MPOHamiltonian(nn), 2),
-                                  VUMPSSvdCut(; trscheme=notrunc()))
-        @test dim(left_virtualspace(state, 1)) < dim(left_virtualspace(state_vs, 1))
+    #     state_vs, _ = changebonds(state, repeat(MPOHamiltonian(nn), 2),
+    #                               VUMPSSvdCut(; trscheme=notrunc()))
+    #     @test dim(left_virtualspace(state, 1)) < dim(left_virtualspace(state_vs, 1))
 
-        state_vs_tr = changebonds(state_vs, SvdCut(; trscheme=truncdim(dim(Dspace))))
-        @test dim(right_virtualspace(state_vs_tr, 1)) < dim(right_virtualspace(state_vs, 1))
-    end
+    #     state_vs_tr = changebonds(state_vs, SvdCut(; trscheme=truncdim(dim(Dspace))))
+    #     @test dim(right_virtualspace(state_vs_tr, 1)) < dim(right_virtualspace(state_vs, 1))
+    # end
 
-    @testset "finite mps" begin
-        #random nn interaction
-        nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
-        nn += nn'
+    # @testset "finite mps" begin
+    #     #random nn interaction
+    #     nn = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
+    #     nn += nn'
 
-        state = FiniteMPS(10, pspace, Dspace)
+    #     state = FiniteMPS(10, pspace, Dspace)
 
-        state_re = changebonds(state,
-                               RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-        @test dot(state, state_re) ≈ 1 atol = 1e-8
+    #     state_re = changebonds(state,
+    #                            RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+    #     @test dot(state, state_re) ≈ 1 atol = 1e-8
 
-        state_oe, _ = changebonds(state, MPOHamiltonian(nn),
-                                  OptimalExpand(;
-                                                trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-        @test dot(state, state_oe) ≈ 1 atol = 1e-8
+    #     state_oe, _ = changebonds(state, MPOHamiltonian(nn),
+    #                               OptimalExpand(;
+    #                                             trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+    #     @test dot(state, state_oe) ≈ 1 atol = 1e-8
 
-        state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
+    #     state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
 
-        @test dim(left_virtualspace(state_tr, 5)) < dim(right_virtualspace(state_oe, 5))
-    end
+    #     @test dim(left_virtualspace(state_tr, 5)) < dim(right_virtualspace(state_oe, 5))
+    # end
 
-    @testset "MPSMultiline" begin
-        o = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
-        mpo = MPOMultiline(o)
+    # @testset "MPSMultiline" begin
+    #     o = TensorMap(rand, ComplexF64, pspace * pspace, pspace * pspace)
+    #     mpo = MPOMultiline(o)
 
-        t = TensorMap(rand, ComplexF64, Dspace * pspace, Dspace)
-        state = MPSMultiline(fill(t, 1, 1))
+    #     t = TensorMap(rand, ComplexF64, Dspace * pspace, Dspace)
+    #     state = MPSMultiline(fill(t, 1, 1))
 
-        state_re = changebonds(state,
-                               RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
-        @test dot(state, state_re) ≈ 1 atol = 1e-8
+    #     state_re = changebonds(state,
+    #                            RandExpand(; trscheme=truncdim(dim(Dspace) * dim(Dspace))))
+    #     @test dot(state, state_re) ≈ 1 atol = 1e-8
 
-        state_oe, _ = changebonds(state, mpo,
-                                  OptimalExpand(;
-                                                trscheme=truncdim(dim(Dspace) *
-                                                                  dim(Dspace))))
-        @test dot(state, state_oe) ≈ 1 atol = 1e-8
+    #     state_oe, _ = changebonds(state, mpo,
+    #                               OptimalExpand(;
+    #                                             trscheme=truncdim(dim(Dspace) *
+    #                                                               dim(Dspace))))
+    #     @test dot(state, state_oe) ≈ 1 atol = 1e-8
 
-        state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
+    #     state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
 
-        @test dim(right_virtualspace(state_tr, 1, 1)) <
-              dim(left_virtualspace(state_oe, 1, 1))
-    end
+    #     @test dim(right_virtualspace(state_tr, 1, 1)) <
+    #           dim(left_virtualspace(state_oe, 1, 1))
+    # end
 end
 
 @testset "Dynamical DMRG" verbose = true begin

--- a/test/states.jl
+++ b/test/states.jl
@@ -178,7 +178,7 @@ end
 
     @testset "Infinite" for (th, D, d) in
                             [(force_planar(transverse_field_ising()), ℙ^10, ℙ^2),
-                             (heisenberg_XXX(SU2Irrep; spin=1), Rep[SU₂](1 => 1, 0 => 3),
+                             (heisenberg_XXX(SU2Irrep; spin=1), Rep[SU₂](1 => 3, 0 => 2),
                               Rep[SU₂](1 => 1))]
         period = rand(1:4)
         ψ = InfiniteMPS(fill(d, period), fill(D, period))


### PR DESCRIPTION
This PR refactors the gauge-fixing algorithm for the uniform case. In particular, it uses IterativeSolvers-inspired algorithm organization, and makes the handling of full-rank tensors for infiniteMPS more explicit.