### PR TITLE
Optimize part of the quasiparticle environment calculation

### DIFF
--- a/src/algorithms/excitation/exci_transfer_system.jl
+++ b/src/algorithms/excitation/exci_transfer_system.jl
@@ -5,18 +5,22 @@ function left_excitation_transfer_system(lBs, H, exci; mom=exci.momentum,
     odim = length(lBs)
 
     for i in 1:odim
-        #this operation can be sped up by at least a factor 2;  found mostly consists of zeros
-        start = found * TransferMatrix(exci.right_gs.AR, H[:], exci.left_gs.AL) /
-                exp(1im * mom * len)
+        # this operation can in principle be even further optimized for larger unit cells
+        # as we only require the terms that end at level i.
+        # this would require to check the finite state machine, and discard non-connected
+        # terms.
+        H_partial = map(site -> H.data[site, 1:i, 1:i], 1:len)
+        T = TransferMatrix(exci.right_gs.AR, H_partial, exci.left_gs.AL)
+        start = scale!(last(found[1:i] * T), cis(-mom * len))
         if exci.trivial && isid(H, i)
-            @plansor start[i][-1 -2; -3 -4] -= start[i][1 4; -3 2] *
-                                               r_RL(exci.right_gs)[2; 3] *
-                                               τ[3 4; 5 1] *
-                                               l_RL(exci.right_gs)[-1; 6] *
-                                               τ[5 6; -4 -2]
+            @plansor start[-1 -2; -3 -4] -= start[1 4; -3 2] *
+                                            r_RL(exci.right_gs)[2; 3] *
+                                            τ[3 4; 5 1] *
+                                            l_RL(exci.right_gs)[-1; 6] *
+                                            τ[5 6; -4 -2]
         end
 
-        found[i] = lBs[i] + start[i]
+        found[i] = add!(start, lBs[i])
 
         if reduce(&, contains.(H.data, i, i))
             if isid(H, i)
@@ -45,17 +49,20 @@ function right_excitation_transfer_system(rBs, H, exci; mom=exci.momentum,
     odim = length(rBs)
 
     for i in odim:-1:1
-        start = TransferMatrix(exci.left_gs.AL, H[:], exci.right_gs.AR) *
-                found *
-                exp(1im * mom * len)
-
+        # this operation can in principle be even further optimized for larger unit cells
+        # as we only require the terms that end at level i.
+        # this would require to check the finite state machine, and discard non-connected
+        # terms.
+        H_partial = map(site -> H.data[site, i:odim, i:odim], 1:len)
+        T = TransferMatrix(exci.left_gs.AL, H_partial, exci.right_gs.AR)
+        start = scale!(first(T * found[i:odim]), cis(mom * len))
         if exci.trivial && isid(H, i)
-            @plansor start[i][-1 -2; -3 -4] -= τ[6 2; 3 4] * start[i][3 4; -3 5] *
-                                               l_LR(exci.right_gs)[5; 2] *
-                                               r_LR(exci.right_gs)[-1; 1] * τ[-2 -4; 1 6]
+            @plansor start[-1 -2; -3 -4] -= τ[6 2; 3 4] * start[3 4; -3 5] *
+                                            l_LR(exci.right_gs)[5; 2] *
+                                            r_LR(exci.right_gs)[-1; 1] * τ[-2 -4; 1 6]
         end
 
-        found[i] = rBs[i] + start[i]
+        found[i] = add!(start, rBs[i])
 
         if reduce(&, contains.(H.data, i, i))
             if isid(H, i)

--- a/src/operators/sparsempo/sparsempo.jl
+++ b/src/operators/sparsempo/sparsempo.jl
@@ -195,12 +195,10 @@ function _envsetypes(d::Tuple)
 end
 
 Base.size(x::SparseMPO) = (size(x.Os, 1),);
-function Base.getindex(x::SparseMPO{S,T,E}, a::Int) where {S,T,E}
-    return SparseMPOSlice{S,T,E}(@view(x.Os[a, :, :]),
-                                 @view(x.domspaces[a, :]),
-                                 @view(x.imspaces[a, :]),
-                                 x.pspaces[a])
-end;
+function Base.getindex(x::SparseMPO, i::Int, j=:, k=:)
+    return SparseMPOSlice(@view(x.Os[i, j, k]), @view(x.domspaces[i, k]),
+                          @view(x.imspaces[i, j]), x.pspaces[i])
+end
 Base.copy(x::SparseMPO) = SparseMPO(copy(x.Os), copy(x.domspaces), copy(x.pspaces));
 TensorKit.space(x::SparseMPO, i) = x.pspaces[i]
 "

--- a/src/operators/sparsempo/sparseslice.jl
+++ b/src/operators/sparsempo/sparseslice.jl
@@ -10,7 +10,8 @@ A view of a sparse MPO at a single position.
 - `imspaces::AbstractVector{S}`: list of right virtual spaces.
 - `pspace::S`: physical space.
 """
-struct SparseMPOSlice{S,T,E,A<:AbstractMatrix{Union{E,T}},B<:AbstractVector{Union{S}}} <: AbstractMatrix{T}
+struct SparseMPOSlice{S,T,E,A<:AbstractMatrix{Union{E,T}},B<:AbstractVector{Union{S}}} <:
+       AbstractMatrix{T}
     Os::A
     domspaces::B
     imspaces::B
@@ -21,9 +22,8 @@ struct SparseMPOSlice{S,T,E,A<:AbstractMatrix{Union{E,T}},B<:AbstractVector{Unio
         sz1, sz2 = size(Os)
         sz1 == length(imspaces) || throw(ArgumentError("imspaces must have length $sz1"))
         sz2 == length(domspaces) || throw(ArgumentError("domspaces must have length $sz2"))
-        new{S,T,E,A,B}(Os, domspaces, imspaces, pspace)
+        return new{S,T,E,A,B}(Os, domspaces, imspaces, pspace)
     end
-    
 end
 
 function Base.getproperty(x::SparseMPOSlice, s::Symbol)

--- a/src/operators/sparsempo/sparseslice.jl
+++ b/src/operators/sparsempo/sparseslice.jl
@@ -10,12 +10,20 @@ A view of a sparse MPO at a single position.
 - `imspaces::AbstractVector{S}`: list of right virtual spaces.
 - `pspace::S`: physical space.
 """
-struct SparseMPOSlice{S,T,E} <: AbstractArray{T,2}
-    Os::SubArray{Union{T,E},2,PeriodicArray{Union{T,E},3},
-                 Tuple{Int,Base.Slice{Base.OneTo{Int}},Base.Slice{Base.OneTo{Int}}},false}
-    domspaces::SubArray{S,1,PeriodicArray{S,2},Tuple{Int,Base.Slice{Base.OneTo{Int}}},false}
-    imspaces::SubArray{S,1,PeriodicArray{S,2},Tuple{Int,Base.Slice{Base.OneTo{Int}}},false}
+struct SparseMPOSlice{S,T,E,A<:AbstractMatrix{Union{E,T}},B<:AbstractVector{Union{S}}} <: AbstractMatrix{T}
+    Os::A
+    domspaces::B
+    imspaces::B
     pspace::S
+    function SparseMPOSlice(Os::A, domspaces::B, imspaces::B,
+                            pspace::S) where {S,T,E,A<:AbstractMatrix{Union{E,T}},
+                                              B<:AbstractVector{Union{S}}}
+        sz1, sz2 = size(Os)
+        sz1 == length(imspaces) || throw(ArgumentError("imspaces must have length $sz1"))
+        sz2 == length(domspaces) || throw(ArgumentError("domspaces must have length $sz2"))
+        new{S,T,E,A,B}(Os, domspaces, imspaces, pspace)
+    end
+    
 end
 
 function Base.getproperty(x::SparseMPOSlice, s::Symbol)


### PR DESCRIPTION
This optimizes the computation of the environments, especially for the cases where the virtual dimension is large, by computing fewer terms.

In order to do so, the `SparseMPOSlice` struct now accepts more generic array types, in order to account for slices that are not `:`.